### PR TITLE
added code to set up a proxy server on port 4243 on all minion nodes.

### DIFF
--- a/collector/Dockerfile
+++ b/collector/Dockerfile
@@ -43,14 +43,13 @@
 # (Ctrl-C will stop and remove the container):
 #   sudo docker run --rm --net=host -p 5555:5555 --name cluster-insight kubernetes/cluster-insight python ./collector.py --debug
 #
-# To run a container from this image in detached production mode:
-# To run as master:
+# To run a container from this image in detached production mode as the master:
 #   sudo docker run -d --net=host -p 5555:5555 --name cluster-insight -e CLUSTER_INSIGHT_MODE=master kubernetes/cluster-insight
 # (this assumes that the Web Server port specified in collector.py is 5555)
 #
-# To run as minion
+# To run a container from this image in detached production mode as a minion:
 #   sudo docker run -d --net=host -p 4243:4243 --name cluster-insight -e CLUSTER_INSIGHT_MODE=minion -v /var/run/docker.sock:/var/run/docker.sock:ro kubernetes/cluster-insight 
-# (this assumes that the docker port specified in docker_proxy.py is 5555)
+# (this assumes that the docker port specified in docker_proxy.py is 4243)
 
 # To check if the Cluster-Insight data collector is running:
 #   sudo docker ps | grep cluster-insight

--- a/collector/Dockerfile
+++ b/collector/Dockerfile
@@ -39,13 +39,18 @@
 # You must configure the Cluster-Insight data collector as explained in the
 # accompanying ../README.md file before running it.
 
-# To run a container from this image in dev/test mode
+# To run a container from this image in dev/test mode as the master:
 # (Ctrl-C will stop and remove the container):
 #   sudo docker run --rm --net=host -p 5555:5555 --name cluster-insight kubernetes/cluster-insight python ./collector.py --debug
 #
 # To run a container from this image in detached production mode:
-#   sudo docker run -d --net=host -p 5555:5555 --name cluster-insight kubernetes/cluster-insight
+# To run as master:
+#   sudo docker run -d --net=host -p 5555:5555 --name cluster-insight -e CLUSTER_INSIGHT_MODE=master kubernetes/cluster-insight
 # (this assumes that the Web Server port specified in collector.py is 5555)
+#
+# To run as minion
+#   sudo docker run -d --net=host -p 4243:4243 --name cluster-insight -e CLUSTER_INSIGHT_MODE=minion -v /var/run/docker.sock:/var/run/docker.sock:ro kubernetes/cluster-insight 
+# (this assumes that the docker port specified in docker_proxy.py is 5555)
 
 # To check if the Cluster-Insight data collector is running:
 #   sudo docker ps | grep cluster-insight
@@ -58,7 +63,6 @@
 
 
 FROM python:2-onbuild
+ENV CLUSTER_INSIGHT_MODE minion
 
-EXPOSE 5555
-
-CMD ["python", "./collector.py"]
+CMD ["python", "./cluster_insight.py"]

--- a/collector/cluster-insight-controller.json
+++ b/collector/cluster-insight-controller.json
@@ -1,0 +1,61 @@
+{
+    "kind": "ReplicationController",
+    "apiVersion": "v1beta3",
+    "metadata": {
+	"name": "cluster-insight-controller",
+	"labels": {
+	    "name": "cluster-insight"
+	}
+    },
+    "spec": {
+	"replicas": 1,
+	"selector": {
+	    "name": "cluster-insight"
+	},
+	"template": {
+	    "metadata": {
+		"labels": {
+		    "name": "cluster-insight"
+		}
+	    },
+	    "spec": {
+		"volumes": [
+		    {
+			"name": "docker-unix-socket",
+			"hostPath": {
+			    "path": "/var/run/docker.sock"
+			}
+		    }
+		],
+		"containers": [
+		    {
+			"name": "cluster-insight",
+                        "ports":[
+                           {
+                              "name":"http-docker",
+                              "containerPort":4243,
+                              "hostPort":4243,
+                              "protocol":"TCP"
+                           }
+                        ],
+                        "env": [
+                           {
+                              "name":"CLUSTER_INSIGHT_MODE",
+                              "value":"minion"
+                           }
+                        ],
+			"image": "kubernetes/cluster-insight",
+			"resources": {},
+			"volumeMounts": [
+			    {
+				"name": "docker-unix-socket",
+				"readOnly": true,
+				"mountPath": "/var/run/docker.sock"
+			    }
+			]
+		    }
+		]
+	    }
+	}
+    }
+}

--- a/collector/cluster_insight.py
+++ b/collector/cluster_insight.py
@@ -16,6 +16,7 @@
 
 
 """Chooses which top level module to run, based on the mode passed in
+the CLUSTER_INSIGHT_MODE environment variable
 """
 
 import argparse

--- a/collector/cluster_insight.py
+++ b/collector/cluster_insight.py
@@ -1,0 +1,55 @@
+#!/usr/bin/python
+#
+# Copyright 2015 The Cluster-Insight Authors. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Chooses which top level module to run, based on the mode passed in
+"""
+
+import argparse
+import os
+
+import collector
+import constants
+import docker_proxy
+
+if __name__ == '__main__':
+  parser = argparse.ArgumentParser(description='Cluster-Insight data collector')
+  parser.add_argument('-d', '--debug', action='store_true',
+                      help='enable debug mode')
+  parser.add_argument('-p', '--port', action='store', type=int,
+                      default=constants.DATA_COLLECTOR_PORT,
+                      help=('data collector port number [default=%d]' %
+                            constants.DATA_COLLECTOR_PORT))
+  parser.add_argument('--docker_port', action='store', type=int,
+                      default=constants.DOCKER_PORT,
+                      help=('Docker port number [default=%d]' %
+                            constants.DOCKER_PORT))
+  parser.add_argument('-w', '--workers', action='store', type=int,
+                      default=0,
+                      help=('number of concurrent workers. A zero or a '
+                            'negative value denotes an automatic calculation '
+                            'of this number. [default=0]'))
+
+  mode = os.environ.get('CLUSTER_INSIGHT_MODE')
+
+  if mode == constants.MODE_MASTER:
+    collector.main()
+  elif mode == constants.MODE_MINION:
+    docker_proxy.main()
+  else:
+    raise Exception('Mode is %s. It can only be one of %s, and %s' 
+		    % (mode, constants.MODE_MINION, constants.MODE_MASTER))
+

--- a/collector/collector.py
+++ b/collector/collector.py
@@ -15,7 +15,8 @@
 # limitations under the License.
 
 
-"""Collects context metadata from multiple places and computes a graph from it.
+"""Runs the cluster insight data collector in master mode. Collects context
+metadata from multiple places and computes a graph from it.
 """
 
 import argparse
@@ -56,40 +57,6 @@ def valid_id(x):
   return utilities.valid_optional_string(x)
 
 
-def make_response(value, attribute_name):
-  """Makes the JSON response containing the given attribute name and value.
-
-  Args:
-    value: the value associated with 'attribute_name'.
-    attribute_name: a string containing the attribute name.
-
-  Returns:
-    A dictionary containing a context-graph successful response with the given
-    attribute name and value.
-  """
-  assert utilities.valid_string(attribute_name)
-  return {'success': True,
-          'timestamp': datetime.datetime.now().isoformat(),
-          attribute_name: value}
-
-
-def make_error(error_message):
-  """Makes the JSON response indicating an error.
-
-  Args:
-    error_message: a string containing the error message describing the
-    failure.
-
-  Returns:
-    A dictionary containing an failed context-graph response with a given
-    error message.
-  """
-  assert utilities.valid_string(error_message)
-  return {'success': False,
-          'timestamp': datetime.datetime.now().isoformat(),
-          'error_message': error_message}
-
-
 @app.route('/', methods=['GET'])
 def home():
   """Returns the response of the '/' endpoint.
@@ -111,13 +78,13 @@ def get_nodes():
   try:
     nodes_list = kubernetes.get_nodes_with_metrics(gs)
   except collector_error.CollectorError as e:
-    return flask.jsonify(make_error(str(e)))
+    return flask.jsonify(utilities.make_error(str(e)))
   except:
     msg = 'kubernetes.get_nodes() failed with exception %s' % sys.exc_info()[0]
     app.logger.exception(msg)
-    return flask.jsonify(make_error(msg))
+    return flask.jsonify(utilities.make_error(msg))
 
-  return flask.jsonify(make_response(nodes_list, 'resources'))
+  return flask.jsonify(utilities.make_response(nodes_list, 'resources'))
 
 
 @app.route('/cluster/resources/services', methods=['GET'])
@@ -131,14 +98,14 @@ def get_services():
   try:
     services_list = kubernetes.get_services(gs)
   except collector_error.CollectorError as e:
-    return flask.jsonify(make_error(str(e)))
+    return flask.jsonify(utilities.make_error(str(e)))
   except:
     msg = ('kubernetes.get_services() failed with exception %s' %
            sys.exc_info()[0])
     app.logger.exception(msg)
-    return flask.jsonify(make_error(msg))
+    return flask.jsonify(utilities.make_error(msg))
 
-  return flask.jsonify(make_response(services_list, 'resources'))
+  return flask.jsonify(utilities.make_response(services_list, 'resources'))
 
 
 @app.route('/cluster/resources/rcontrollers', methods=['GET'])
@@ -152,14 +119,14 @@ def get_rcontrollers():
   try:
     rcontrollers_list = kubernetes.get_rcontrollers(gs)
   except collector_error.CollectorError as e:
-    return flask.jsonify(make_error(str(e)))
+    return flask.jsonify(utilities.make_error(str(e)))
   except:
     msg = ('kubernetes.get_rcontrollers() failed with exception %s' %
            sys.exc_info()[0])
     app.logger.exception(msg)
-    return flask.jsonify(make_error(msg))
+    return flask.jsonify(utilities.make_error(msg))
 
-  return flask.jsonify(make_response(rcontrollers_list, 'resources'))
+  return flask.jsonify(utilities.make_response(rcontrollers_list, 'resources'))
 
 
 @app.route('/cluster/resources/pods', methods=['GET'])
@@ -173,13 +140,13 @@ def get_pods():
   try:
     pods_list = kubernetes.get_pods(gs, None)
   except collector_error.CollectorError as e:
-    return flask.jsonify(make_error(str(e)))
+    return flask.jsonify(utilities.make_error(str(e)))
   except:
     msg = 'kubernetes.get_pods() failed with exception %s' % sys.exc_info()[0]
     app.logger.exception(msg)
-    return flask.jsonify(make_error(msg))
+    return flask.jsonify(utilities.make_error(msg))
 
-  return flask.jsonify(make_response(pods_list, 'resources'))
+  return flask.jsonify(utilities.make_response(pods_list, 'resources'))
 
 
 @app.route('/cluster/resources/containers', methods=['GET'])
@@ -199,13 +166,13 @@ def get_containers():
       containers.extend(docker.get_containers_with_metrics(gs, docker_host))
 
   except collector_error.CollectorError as e:
-    return flask.jsonify(make_error(str(e)))
+    return flask.jsonify(utilities.make_error(str(e)))
   except:
     msg = 'get_containers() failed with exception %s' % sys.exc_info()[0]
     app.logger.exception(msg)
-    return flask.jsonify(make_error(msg))
+    return flask.jsonify(utilities.make_error(msg))
 
-  return flask.jsonify(make_response(containers, 'resources'))
+  return flask.jsonify(utilities.make_response(containers, 'resources'))
 
 
 @app.route('/cluster/resources/processes', methods=['GET'])
@@ -227,13 +194,13 @@ def get_processes():
         processes.extend(docker.get_processes(gs, docker_host, container_id))
 
   except collector_error.CollectorError as e:
-    return flask.jsonify(make_error(str(e)))
+    return flask.jsonify(utilities.make_error(str(e)))
   except:
     msg = 'get_processes() failed with exception %s' % sys.exc_info()[0]
     app.logger.exception(msg)
-    return flask.jsonify(make_error(msg))
+    return flask.jsonify(utilities.make_error(msg))
 
-  return flask.jsonify(make_response(processes, 'resources'))
+  return flask.jsonify(utilities.make_response(processes, 'resources'))
 
 
 @app.route('/cluster/resources/images', methods=['GET'])
@@ -255,15 +222,15 @@ def get_images():
         images_dict[image['id']] = image
 
   except collector_error.CollectorError as e:
-    return flask.jsonify(make_error(str(e)))
+    return flask.jsonify(utilities.make_error(str(e)))
   except:
     msg = 'kubernetes.get_images() failed with exception %s' % sys.exc_info()[0]
     app.logger.exception(msg)
-    return flask.jsonify(make_error(msg))
+    return flask.jsonify(utilities.make_error(msg))
 
   # The images list is sorted by increasing identifiers.
   images_list = [images_dict[key] for key in sorted(images_dict.keys())]
-  return flask.jsonify(make_response(images_list, 'resources'))
+  return flask.jsonify(utilities.make_response(images_list, 'resources'))
 
 
 @app.route('/debug', methods=['GET'])
@@ -277,12 +244,12 @@ def get_debug():
   try:
     return context.compute_graph(gs, 'dot')
   except collector_error.CollectorError as e:
-    return flask.jsonify(make_error(str(e)))
+    return flask.jsonify(utilities.make_error(str(e)))
   except:
     msg = ('compute_graph(\"dot\") failed with exception %s' %
            sys.exc_info()[0])
     app.logger.exception(msg)
-    return flask.jsonify(make_error(msg))
+    return flask.jsonify(utilities.make_error(msg))
 
 
 @app.route('/cluster/resources', methods=['GET'])
@@ -297,12 +264,12 @@ def get_resources():
     response = context.compute_graph(gs, 'resources')
     return flask.jsonify(response)
   except collector_error.CollectorError as e:
-    return flask.jsonify(make_error(str(e)))
+    return flask.jsonify(utilities.make_error(str(e)))
   except:
     msg = ('compute_graph(\"resources\") failed with exception %s' %
            sys.exc_info()[0])
     app.logger.exception(msg)
-    return flask.jsonify(make_error(msg))
+    return flask.jsonify(utilities.make_error(msg))
 
 
 @app.route('/cluster', methods=['GET'])
@@ -317,12 +284,12 @@ def get_cluster():
     response = context.compute_graph(gs, 'context_graph')
     return flask.jsonify(response)
   except collector_error.CollectorError as e:
-    return flask.jsonify(make_error(str(e)))
+    return flask.jsonify(utilities.make_error(str(e)))
   except:
     msg = ('compute_graph(\"context_graph\") failed with exception %s' %
            sys.exc_info()[0])
     app.logger.exception(msg)
-    return flask.jsonify(make_error(msg))
+    return flask.jsonify(utilities.make_error(msg))
 
 
 @app.route('/version', methods=['GET'])
@@ -335,13 +302,13 @@ def get_version():
   gs = app.context_graph_global_state
   try:
     version = docker.get_version(gs)
-    return flask.jsonify(make_response(version, 'version'))
+    return flask.jsonify(utilities.make_response(version, 'version'))
   except collector_error.CollectorError as e:
-    return flask.jsonify(make_error(str(e)))
+    return flask.jsonify(utilities.make_error(str(e)))
   except:
     msg = ('get_version() failed with exception %s' % sys.exc_info()[0])
     app.logger.exception(msg)
-    return flask.jsonify(make_error(msg))
+    return flask.jsonify(utilities.make_error(msg))
 
 
 @app.route('/healthz', methods=['GET'])
@@ -351,7 +318,7 @@ def get_health():
   Returns:
   A successful response containing the attribute 'health' and the value 'OK'.
   """
-  return flask.jsonify(make_response('OK', 'health'))
+  return flask.jsonify(utilities.make_response('OK', 'health'))
 
 
 # Starts the web server and listen on all external IPs associated with this

--- a/collector/collector.py
+++ b/collector/collector.py
@@ -356,7 +356,7 @@ def get_health():
 
 # Starts the web server and listen on all external IPs associated with this
 # host.
-if __name__ == '__main__':
+def main():
   parser = argparse.ArgumentParser(description='Cluster-Insight data collector')
   parser.add_argument('-d', '--debug', action='store_true',
                       help='enable debug mode')
@@ -384,3 +384,7 @@ if __name__ == '__main__':
   app.context_graph_global_state = g_state
 
   app.run(host='0.0.0.0', port=args.port, debug=args.debug)
+
+
+if __name__ == '__main__':
+  main()

--- a/collector/constants.py
+++ b/collector/constants.py
@@ -41,3 +41,6 @@ MAX_CONCURRENT_WORKERS = 10
 # These calls are executed by concurrent worker threads, so they may generate
 # heavy load on the backend.
 MAX_CONCURRENT_COMPUTE_GRAPH = 2
+
+MODE_MINION = 'minion'
+MODE_MASTER = 'master'

--- a/collector/docker.py
+++ b/collector/docker.py
@@ -615,6 +615,11 @@ def get_version(gs):
     CollectorError: in case of any error to compute the running image
       information.
   """
+  #TODO(EranGabber): Edit this code to get the version from one of the minions.
+  # Return unknown for now, so we don't have to access the docker API on master.
+  return '_unknown_'
+  
+  """
   version, timestamp_secs = gs.get_version_cache().lookup('')
   if timestamp_secs is not None:
     assert utilities.valid_string(version)
@@ -684,3 +689,4 @@ def get_version(gs):
   ret_value = gs.get_version_cache().update('', version)
   gs.logger_info('get_version() returns: %s', ret_value)
   return ret_value
+  """

--- a/collector/docker_proxy.py
+++ b/collector/docker_proxy.py
@@ -1,0 +1,125 @@
+#!/usr/bin/python
+#
+# Copyright 2015 The Cluster-Insight Authors. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import argparse
+import datetime
+import flask
+from flask_cors import CORS
+import json
+import logging
+import requests_unixsocket
+import sys
+import types
+
+import constants
+
+app = flask.Flask(__name__)
+logger = logging.getLogger(__name__)
+
+
+# enable cross-origin resource sharing (CORS) HTTP headers on all routes
+cors = CORS(app)
+
+# Start unix socket session
+session = requests_unixsocket.Session()
+
+# Constant pointing to the url for the docker unix socket
+LOCAL_DOCKER_HOST= 'http+unix://%2Fvar%2Frun%2Fdocker.sock'
+
+
+def make_error(error_message):
+  """Returns a JSON response indicating an error."""
+  assert isinstance(error_message, types.StringTypes) and error_message
+  result = {
+      'success': False,
+      'timestamp': datetime.datetime.now().isoformat(),
+      'error_message': error_message
+  }
+  return result
+
+
+def get_response(api):
+  """This method passes the API call to the docker unix host, 
+  and returns the json response."""
+  logger.info('Getting response for API: %s', api)
+  try:
+    r = session.get('{docker_host}{url}'.format(
+  	  docker_host=LOCAL_DOCKER_HOST, url=api))
+    if r.status_code != 200:
+      logger.info('%d', r.status_code)
+      raise Exception('Error accessing %s API', api)
+
+    else:
+      return flask.make_response(json.dumps(r.json()), 
+		      r.status_code, 
+  		      {'Content-Type': 'application/json'})
+  except Exception as e:
+    logger.error(e, exc_info=True)
+    exc_type, value, _ = sys.exc_info()
+    return flask.jsonify(make_error(
+	    'Failed to retrieve %s with exception %s: %s' 
+	    % (api, exc_type, value)))
+
+
+
+# Calls to support 
+# 1. /containers/{container_id}/json
+# 2. /containers/json
+# 3. /containers/{container_id}/top?ps_args=aux
+# 4. /containers/{image_id}/json
+
+@app.route('/containers/json', methods=['GET'])
+def get_all_containers():
+  return get_response('/containers/json')
+
+@app.route('/containers/<container_id>/json', methods=['GET'])
+def get_one_container(container_id):
+  return get_response('/containers/{cid}/json'.format(cid=container_id))
+
+@app.route('/containers/<image_id>/json', methods=['GET'])
+def get_one_image(image_id):
+  return get_response('/containers/{iid}/json'.format(iid=image_id))
+
+@app.route('/containers/<container_id>/top', methods=['GET'])
+def get_one_container_processes(container_id):
+  qargs = flask.request.args.to_dict() if flask.request.args else {}
+  if qargs.get('ps_args') != 'aux' or len(qargs.keys()) > 1:
+    return flask.jsonify(make_error(
+	    'For /container/{container_id}/top, the only allowed arg is ps_args=aux.'
+	    '%s is not allowed' % (qargs)))
+
+  return get_response('/containers/{cid}/top?ps_args=aux'.format(cid=container_id))
+
+
+# Starts the web server and listen on all external IPs associated with this
+# host.
+def main():
+  parser = argparse.ArgumentParser(description='Cluster-Insight docker data collector')
+  parser.add_argument('-d', '--debug', action='store_true',
+                      help='enable debug mode')
+  parser.add_argument('--docker_port', action='store', type=int,
+                      default=constants.DOCKER_PORT,
+                      help=('Docker port number [default=%d]' %
+                            constants.DOCKER_PORT))
+
+  args = parser.parse_args()
+  app.logger.setLevel(logging.DEBUG if args.debug else logging.INFO)
+  app.run(host='0.0.0.0', port=args.docker_port, debug=args.debug)
+
+
+if __name__ == '__main__':
+  main()

--- a/collector/requirements.txt
+++ b/collector/requirements.txt
@@ -1,3 +1,4 @@
 flask
 flask-cors
 requests
+requests_unixsocket

--- a/collector/utilities.py
+++ b/collector/utilities.py
@@ -544,3 +544,37 @@ def get_short_container_name(container, parent_pod):
       return cname
 
   return None
+
+
+def make_response(value, attribute_name):
+  """Makes the JSON response containing the given attribute name and value.
+
+  Args:
+    value: the value associated with 'attribute_name'.
+    attribute_name: a string containing the attribute name.
+
+  Returns:
+    A dictionary containing a context-graph successful response with the given
+    attribute name and value.
+  """
+  assert valid_string(attribute_name)
+  return {'success': True,
+          'timestamp': datetime.datetime.now().isoformat(),
+          attribute_name: value}
+
+
+def make_error(error_message):
+  """Makes the JSON response indicating an error.
+
+  Args:
+    error_message: a string containing the error message describing the
+    failure.
+
+  Returns:
+    A dictionary containing an failed context-graph response with a given
+    error message.
+  """
+  assert valid_string(error_message)
+  return {'success': False,
+          'timestamp': datetime.datetime.now().isoformat(),
+          'error_message': error_message}


### PR DESCRIPTION
1. Added code to run the cluster-insight collector in "master" and "minion" modes. The "master" mode is the same as the previous code: it starts a web server and it collects information from Kubernetes and Docker daemons.
2. The "minion" mode acts as a proxy to the local Docker daemon. It proxies specific GET requests to the local Docker daemon. The minion mode alleviates the need to modify the Docker daemon configuration,
restart the Docker daemon, or open an IP domain socket for the daemon.
3. Added a script for replication controller that sets up one Cluster-Insight collector in minion mode. We can run the cluster-insight collector on all minion modes by "kubectl create -f cluster-insight-controller.json" followed by "kubectl resize --replicas=N replicationcontrollers cluster-insight".

