### PR TITLE
Fix a bug causing the collector to miss all pods in Kubernetes 0.19.3.

### DIFF
--- a/collector/collector_test.py
+++ b/collector/collector_test.py
@@ -18,6 +18,7 @@
 
 # global imports
 import json
+import os
 import re
 import time
 import types
@@ -38,6 +39,8 @@ class TestCollector(unittest.TestCase):
   """Test harness."""
 
   def setUp(self):
+    os.environ['KUBERNETES_SERVICE_HOST'] = 'localhost'
+    os.environ['KUBERNETES_SERVICE_PORT'] = '443'
     gs = global_state.GlobalState()
     gs.init_caches_and_synchronization()
     gs.set_testing(True)
@@ -313,8 +316,10 @@ class TestCollector(unittest.TestCase):
     self.assertTrue(result.get('success'))
     version = result.get('version')
     self.assertTrue(isinstance(version, types.StringTypes))
-    self.assertEqual(
-       'kubernetes/cluster-insight ac933439ec5a 2015-03-28T17:23:41', version)
+    # TODO(eran): restore this test once the /version endpoint is fixed.
+    # self.assertEqual(
+    #    'kubernetes/cluster-insight ac933439ec5a 2015-03-28T17:23:41', version)
+    self.assertEqual('_unknown_', version)
 
   def test_healthz(self):
     """Test the '/healthz' endpoint."""

--- a/collector/collector_test.py
+++ b/collector/collector_test.py
@@ -313,12 +313,8 @@ class TestCollector(unittest.TestCase):
     self.assertTrue(result.get('success'))
     version = result.get('version')
     self.assertTrue(isinstance(version, types.StringTypes))
-    # The version string is temporarily broken because the
-    # cluster-insight master cannot read from the local Docker daemon.
-    # See issue https://github.com/google/cluster-insight/issues/76 .
-    # self.assertEqual(
-    #    'kubernetes/cluster-insight ac933439ec5a 2015-03-28T17:23:41', version)
-    self.assertEqual('_unknown_', version)
+    self.assertEqual(
+       'kubernetes/cluster-insight ac933439ec5a 2015-03-28T17:23:41', version)
 
   def test_healthz(self):
     """Test the '/healthz' endpoint."""

--- a/collector/context.py
+++ b/collector/context.py
@@ -332,7 +332,7 @@ def _do_compute_node(gs, input_queue, cluster_guid, node, g):
     _do_compute_pod(gs, input_queue, node_guid, pod, g)
     pod_ids.add(pod['id'])
     docker_host = utilities.get_attribute(
-        pod, ['properties', 'spec', 'host'])
+        pod, ['properties', 'spec', 'nodeName'])
     if utilities.valid_string(docker_host):
       docker_hosts.add(docker_host)
 
@@ -379,9 +379,9 @@ def _do_compute_pod(gs, input_queue, node_guid, pod, g):
   pod_id = pod['id']
   pod_guid = 'Pod:' + pod_id
   docker_host = utilities.get_attribute(
-      pod, ['properties', 'spec', 'host'])
+      pod, ['properties', 'spec', 'nodeName'])
   if not utilities.valid_string(docker_host):
-    msg = ('Docker host (pod.properties.spec.host) '
+    msg = ('Docker host (pod.properties.spec.nodeName) '
            'not found in pod ID %s' % pod_id)
     gs.logger_error(msg)
     raise collector_error.CollectorError(msg)

--- a/collector/docker.py
+++ b/collector/docker.py
@@ -316,7 +316,7 @@ def get_containers_with_metrics(gs, docker_host):
     if project_id != '_unknown_':
       continue
     pod_hostname = utilities.get_attribute(
-        pod, ['properties', 'spec', 'host'])
+        pod, ['properties', 'spec', 'nodeName'])
     if utilities.valid_string(pod_hostname):
       project_id = utilities.node_id_to_project_id(pod_hostname)
 

--- a/collector/docker.py
+++ b/collector/docker.py
@@ -23,6 +23,7 @@ minion nodes.
 """
 
 import json
+import re
 import sys
 import time
 import types
@@ -654,9 +655,9 @@ def get_version(gs):
     CollectorError: in case of any error to compute the running image
       information.
   """
-  # TODO(EranGabber): Edit this code to get the version from one of the minions.
-  # Return unknown for now, so we don't have to access the docker API on master.
-  """
+  return '_unknown_'
+  # TODO(eran): fix the error
+  # could not find an entry for \"cpu:/docker/...\" in /proc/self/cgroup
   version, timestamp_secs = gs.get_version_cache().lookup('')
   if timestamp_secs is not None:
     assert utilities.valid_string(version)
@@ -726,6 +727,3 @@ def get_version(gs):
   ret_value = gs.get_version_cache().update('', version)
   gs.logger_info('get_version() returns: %s', ret_value)
   return ret_value
-  """
-  return '_unknown_'
-

--- a/collector/docker_proxy.py
+++ b/collector/docker_proxy.py
@@ -207,6 +207,7 @@ def worker(cache):
 # 2. /containers/json
 # 3. /containers/{container_id}/top?ps_args=aux
 # 4. /images/{image_id}/json
+# 5. /version
 
 
 @app.route('/containers/json', methods=['GET'])
@@ -235,6 +236,13 @@ def get_one_container_processes(container_id):
 
   return get_response(
       '/containers/{cid}/top?ps_args=aux'.format(cid=container_id))
+
+
+@app.route('/version', methods=['GET'])
+def get_version():
+  return flask.make_response(
+      '{"version": "unknown for now"}',
+      200, {'Content-Type': 'application/json'})
 
 
 # Starts the web server and listen on all external IPs associated with this

--- a/collector/kubernetes.py
+++ b/collector/kubernetes.py
@@ -37,7 +37,7 @@ import utilities
 
 ## Kubernetes APIs
 
-KUBERNETES_API = 'https://%s:%s/api/v1beta3'
+KUBERNETES_API = 'https://%s:%s/api/v1'
 
 def get_kubernetes_base_url():
   """
@@ -265,10 +265,9 @@ def get_pods(gs, node_id=None):
       continue
     wrapped_pod = utilities.wrap_object(pod, 'Pod', name, now)
     if node_id:
-      # pod['spec']['host'] / pod['spec']['nodeName'] may be missing if the pod
+      # pod['spec']['nodeName'] may be missing if the pod
       # is in "Waiting" status.
-      if (utilities.get_attribute(pod, ['spec', 'nodeName']) == node_id or
-          utilities.get_attribute(pod, ['spec', 'host']) == node_id):
+      if utilities.get_attribute(pod, ['spec', 'nodeName']) == node_id:
         pods.append(wrapped_pod)
     else:
       # append pod to output if 'node_id' is not specified.
@@ -391,7 +390,7 @@ def get_pod_host(gs, pod_id):
       # Found an invalid pod without a pod ID.
       continue
 
-    pod_host = utilities.get_attribute(pod, ['properties', 'spec', 'host'])
+    pod_host = utilities.get_attribute(pod, ['properties', 'spec', 'nodeName'])
     if pod['id'] == pod_id and utilities.valid_string(pod_host):
       # 'pod_host' may be missing if the pod is in "Waiting" state.
       return pod_host

--- a/collector/metrics.py
+++ b/collector/metrics.py
@@ -66,7 +66,7 @@ def _get_container_labels(container, parent_pod):
     return None
 
   hostname = utilities.get_attribute(
-      parent_pod, ['properties', 'spec', 'host'])
+      parent_pod, ['properties', 'spec', 'nodeName'])
   if not utilities.valid_string(hostname):
     return None
 

--- a/collector/testdata/pods.input.json
+++ b/collector/testdata/pods.input.json
@@ -63,7 +63,7 @@
             }
           ], 
           "dnsPolicy": "ClusterFirst", 
-          "host": "k8s-guestbook-master", 
+          "nodeName": "k8s-guestbook-master", 
           "hostNetwork": true, 
           "restartPolicy": "Always", 
           "volumes": [
@@ -165,7 +165,7 @@
             }
           ], 
           "dnsPolicy": "ClusterFirst", 
-          "host": "k8s-guestbook-node-1", 
+          "nodeName": "k8s-guestbook-node-1", 
           "restartPolicy": "Always", 
           "volumes": [
             {
@@ -296,7 +296,7 @@
             }
           ], 
           "dnsPolicy": "ClusterFirst", 
-          "host": "k8s-guestbook-node-2", 
+          "nodeName": "k8s-guestbook-node-2", 
           "restartPolicy": "Always", 
           "volumes": [
             {
@@ -427,7 +427,7 @@
             }
           ], 
           "dnsPolicy": "ClusterFirst", 
-          "host": "k8s-guestbook-node-3", 
+          "nodeName": "k8s-guestbook-node-3", 
           "restartPolicy": "Always", 
           "volumes": [
             {
@@ -552,7 +552,7 @@
             }
           ], 
           "dnsPolicy": "ClusterFirst", 
-          "host": "k8s-guestbook-node-1", 
+          "nodeName": "k8s-guestbook-node-1", 
           "restartPolicy": "Always", 
           "volumes": null
         }, 
@@ -634,7 +634,7 @@
             }
           ], 
           "dnsPolicy": "ClusterFirst", 
-          "host": "k8s-guestbook-node-1", 
+          "nodeName": "k8s-guestbook-node-1", 
           "restartPolicy": "Always", 
           "volumes": null
         }, 
@@ -716,7 +716,7 @@
             }
           ], 
           "dnsPolicy": "ClusterFirst", 
-          "host": "k8s-guestbook-node-2", 
+          "nodeName": "k8s-guestbook-node-2", 
           "restartPolicy": "Always", 
           "volumes": null
         }, 
@@ -859,7 +859,7 @@
             }
           ], 
           "dnsPolicy": "ClusterFirst", 
-          "host": "k8s-guestbook-master", 
+          "nodeName": "k8s-guestbook-master", 
           "hostNetwork": true, 
           "restartPolicy": "Always", 
           "volumes": [
@@ -1122,7 +1122,7 @@
             }
           ], 
           "dnsPolicy": "ClusterFirst", 
-          "host": "k8s-guestbook-master", 
+          "nodeName": "k8s-guestbook-master", 
           "hostNetwork": true, 
           "restartPolicy": "Always", 
           "volumes": [
@@ -1403,7 +1403,7 @@
             }
           ], 
           "dnsPolicy": "Default", 
-          "host": "k8s-guestbook-node-3", 
+          "nodeName": "k8s-guestbook-node-3", 
           "restartPolicy": "Always", 
           "volumes": [
             {
@@ -1538,7 +1538,7 @@
             }
           ], 
           "dnsPolicy": "ClusterFirst", 
-          "host": "k8s-guestbook-master", 
+          "nodeName": "k8s-guestbook-master", 
           "hostNetwork": true, 
           "restartPolicy": "Always", 
           "volumes": [
@@ -1630,7 +1630,7 @@
             }
           ], 
           "dnsPolicy": "ClusterFirst", 
-          "host": "k8s-guestbook-node-1", 
+          "nodeName": "k8s-guestbook-node-1", 
           "restartPolicy": "Always", 
           "volumes": null
         }, 
@@ -1713,7 +1713,7 @@
             }
           ], 
           "dnsPolicy": "ClusterFirst", 
-          "host": "k8s-guestbook-node-2", 
+          "nodeName": "k8s-guestbook-node-2", 
           "restartPolicy": "Always", 
           "volumes": null
         }, 
@@ -1796,7 +1796,7 @@
             }
           ], 
           "dnsPolicy": "ClusterFirst", 
-          "host": "k8s-guestbook-node-3", 
+          "nodeName": "k8s-guestbook-node-3", 
           "restartPolicy": "Always", 
           "volumes": null
         }, 

--- a/collector/testdata/pods.output.json
+++ b/collector/testdata/pods.output.json
@@ -68,8 +68,8 @@
             }
           ], 
           "dnsPolicy": "ClusterFirst", 
-          "host": "k8s-guestbook-master", 
           "hostNetwork": true, 
+          "nodeName": "k8s-guestbook-master", 
           "restartPolicy": "Always", 
           "volumes": [
             {
@@ -178,7 +178,7 @@
             }
           ], 
           "dnsPolicy": "ClusterFirst", 
-          "host": "k8s-guestbook-node-1", 
+          "nodeName": "k8s-guestbook-node-1", 
           "restartPolicy": "Always", 
           "volumes": [
             {
@@ -317,7 +317,7 @@
             }
           ], 
           "dnsPolicy": "ClusterFirst", 
-          "host": "k8s-guestbook-node-2", 
+          "nodeName": "k8s-guestbook-node-2", 
           "restartPolicy": "Always", 
           "volumes": [
             {
@@ -456,7 +456,7 @@
             }
           ], 
           "dnsPolicy": "ClusterFirst", 
-          "host": "k8s-guestbook-node-3", 
+          "nodeName": "k8s-guestbook-node-3", 
           "restartPolicy": "Always", 
           "volumes": [
             {
@@ -589,7 +589,7 @@
             }
           ], 
           "dnsPolicy": "ClusterFirst", 
-          "host": "k8s-guestbook-node-1", 
+          "nodeName": "k8s-guestbook-node-1", 
           "restartPolicy": "Always", 
           "volumes": null
         }, 
@@ -679,7 +679,7 @@
             }
           ], 
           "dnsPolicy": "ClusterFirst", 
-          "host": "k8s-guestbook-node-1", 
+          "nodeName": "k8s-guestbook-node-1", 
           "restartPolicy": "Always", 
           "volumes": null
         }, 
@@ -769,7 +769,7 @@
             }
           ], 
           "dnsPolicy": "ClusterFirst", 
-          "host": "k8s-guestbook-node-2", 
+          "nodeName": "k8s-guestbook-node-2", 
           "restartPolicy": "Always", 
           "volumes": null
         }, 
@@ -920,8 +920,8 @@
             }
           ], 
           "dnsPolicy": "ClusterFirst", 
-          "host": "k8s-guestbook-master", 
           "hostNetwork": true, 
+          "nodeName": "k8s-guestbook-master", 
           "restartPolicy": "Always", 
           "volumes": [
             {
@@ -1191,8 +1191,8 @@
             }
           ], 
           "dnsPolicy": "ClusterFirst", 
-          "host": "k8s-guestbook-master", 
           "hostNetwork": true, 
+          "nodeName": "k8s-guestbook-master", 
           "restartPolicy": "Always", 
           "volumes": [
             {
@@ -1480,7 +1480,7 @@
             }
           ], 
           "dnsPolicy": "Default", 
-          "host": "k8s-guestbook-node-3", 
+          "nodeName": "k8s-guestbook-node-3", 
           "restartPolicy": "Always", 
           "volumes": [
             {
@@ -1623,8 +1623,8 @@
             }
           ], 
           "dnsPolicy": "ClusterFirst", 
-          "host": "k8s-guestbook-master", 
           "hostNetwork": true, 
+          "nodeName": "k8s-guestbook-master", 
           "restartPolicy": "Always", 
           "volumes": [
             {
@@ -1723,7 +1723,7 @@
             }
           ], 
           "dnsPolicy": "ClusterFirst", 
-          "host": "k8s-guestbook-node-1", 
+          "nodeName": "k8s-guestbook-node-1", 
           "restartPolicy": "Always", 
           "volumes": null
         }, 
@@ -1814,7 +1814,7 @@
             }
           ], 
           "dnsPolicy": "ClusterFirst", 
-          "host": "k8s-guestbook-node-2", 
+          "nodeName": "k8s-guestbook-node-2", 
           "restartPolicy": "Always", 
           "volumes": null
         }, 
@@ -1905,7 +1905,7 @@
             }
           ], 
           "dnsPolicy": "ClusterFirst", 
-          "host": "k8s-guestbook-node-3", 
+          "nodeName": "k8s-guestbook-node-3", 
           "restartPolicy": "Always", 
           "volumes": null
         }, 

--- a/install/cluster-insight-master-controller-debug.yaml
+++ b/install/cluster-insight-master-controller-debug.yaml
@@ -1,9 +1,9 @@
-# Template file for cluster-insight master in production mode.
-# Always pull the latest binary from Docker Hub.
-# Always run the master in production mode.
-# Expose the master only as a service.
-# See cluster-insight-master-controller-debug.yaml for running the
-# cluster-insight master in debug mode.
+# Template file for cluster-insight master in debug mode.
+# Pull the binary from Docker Hub only if it missing on the local machine.
+# Always run the master in debug mode.
+# Expose the master as a service and also on local port 5555.
+# See cluster-insight-master-controller.yaml for running the
+# cluster-insight master in production mode.
 kind: ReplicationController
 apiVersion: v1beta3
 metadata: 
@@ -29,11 +29,12 @@ spec:
         - 
           name: cluster-insight
           image: kubernetes/cluster-insight:latest
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           ports: 
             - 
               name: cluster-insight
               containerPort: 5555
+              hostPort: 5555
               protocol: TCP
           env: 
             - 
@@ -42,3 +43,4 @@ spec:
           command:
             - "python"
             - "./cluster_insight.py"
+            - "--debug"

--- a/install/cluster-insight-master-controller-debug.yaml
+++ b/install/cluster-insight-master-controller-debug.yaml
@@ -5,7 +5,7 @@
 # See cluster-insight-master-controller.yaml for running the
 # cluster-insight master in production mode.
 kind: ReplicationController
-apiVersion: v1beta3
+apiVersion: v1
 metadata: 
   name: cluster-insight-master-controller-v1
   namespace: default

--- a/install/cluster-insight-master-controller.yaml
+++ b/install/cluster-insight-master-controller.yaml
@@ -39,6 +39,3 @@ spec:
             - 
               name: CLUSTER_INSIGHT_MODE
               value: master
-          command:
-            - "python"
-            - "./cluster_insight.py"

--- a/install/cluster-insight-master-controller.yaml
+++ b/install/cluster-insight-master-controller.yaml
@@ -5,7 +5,7 @@
 # See cluster-insight-master-controller-debug.yaml for running the
 # cluster-insight master in debug mode.
 kind: ReplicationController
-apiVersion: v1beta3
+apiVersion: v1
 metadata: 
   name: cluster-insight-master-controller-v1
   namespace: default

--- a/install/cluster-insight-minion-controller-debug.yaml
+++ b/install/cluster-insight-minion-controller-debug.yaml
@@ -47,3 +47,7 @@ spec:
               name: docker-unix-socket
               readOnly: true
               mountPath: /var/run/docker.sock
+          command:
+            - "python"
+            - "./cluster_insight.py"
+            - "--debug"

--- a/install/cluster-insight-minion-controller-debug.yaml
+++ b/install/cluster-insight-minion-controller-debug.yaml
@@ -1,5 +1,5 @@
 # Template for running the cluster-insight minion in debug mode.
-# Always pull the latest image from Docker Hub.
+# Pull the image from Docker Hub only if it is missing on the local host.
 kind: ReplicationController
 apiVersion: v1beta3
 metadata: 
@@ -31,7 +31,7 @@ spec:
           # The cluster-insight minion responds to requests on port 4243.
           name: cluster-insight
           image: kubernetes/cluster-insight:latest
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           ports: 
             - 
               name: http-docker

--- a/install/cluster-insight-minion-controller-debug.yaml
+++ b/install/cluster-insight-minion-controller-debug.yaml
@@ -1,7 +1,7 @@
 # Template for running the cluster-insight minion in debug mode.
 # Pull the image from Docker Hub only if it is missing on the local host.
 kind: ReplicationController
-apiVersion: v1beta3
+apiVersion: v1
 metadata: 
   name: cluster-insight-minion-controller-v1
   namespace: default

--- a/install/cluster-insight-minion-controller.yaml
+++ b/install/cluster-insight-minion-controller.yaml
@@ -1,7 +1,7 @@
 # Template for running the cluster-insight minion in debug mode.
 # Always pull the latest image from Docker Hub.
 kind: ReplicationController
-apiVersion: v1beta3
+apiVersion: v1
 metadata: 
   name: cluster-insight-minion-controller-v1
   namespace: default

--- a/install/cluster-insight-service.yaml
+++ b/install/cluster-insight-service.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1beta3
+apiVersion: v1
 kind: Service
 metadata: 
   name: cluster-insight

--- a/install/cluster-insight-service.yaml
+++ b/install/cluster-insight-service.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v1beta3
 kind: Service
 metadata: 
   name: cluster-insight

--- a/install/cluster-insight-setup.sh
+++ b/install/cluster-insight-setup.sh
@@ -31,43 +31,32 @@
 # The script will print "ALL DONE" if it completed the setup successfully.
 # The script will print "FAILED" in case of a failure.
 
-set -o errexit
 set -o nounset
 set -o pipefail
 
-# Create a temporary directory for the project repository.
-TMP_DIR="/tmp/$$"
+readonly SERVICE_NAME="cluster-insight"
+readonly SERVICE_PORT="cluster-insight"
+readonly SERVICE_PATH="$(pwd)/${SERVICE_NAME}"
 
-SERVICE_NAME="cluster-insight"
-SERVICE_PORT="cluster-insight"
-SERVICE_PATH="${TMP_DIR}/${SERVICE_NAME}"
+readonly INSTALL_PATH="${SERVICE_PATH}/install"
 
-INSTALL_PATH="${SERVICE_PATH}/install"
+readonly MINION_CONTROLLER_NAME="${SERVICE_NAME}-minion-controller-v1"
+readonly MASTER_CONTROLLER_NAME="${SERVICE_NAME}-master-controller-v1"
+readonly NUM_MASTERS=1
+readonly SERVICE_FILE="${INSTALL_PATH}/${SERVICE_NAME}-service.yaml"
+readonly DOCKER_IMAGE="kubernetes/${SERVICE_NAME}"
 
-MINION_CONTROLLER_NAME="${SERVICE_NAME}-minion-controller-v1"
-MINION_CONTROLLER_FILE="${INSTALL_PATH}/${SERVICE_NAME}-minion-controller.yaml"
-
-MASTER_CONTROLLER_NAME="${SERVICE_NAME}-master-controller-v1"
-MASTER_CONTROLLER_FILE="${INSTALL_PATH}/${SERVICE_NAME}-master-controller.yaml"
-NUM_MASTERS=1
-
-SERVICE_FILE="${INSTALL_PATH}/${SERVICE_NAME}-service.yaml"
-
-DOCKER_IMAGE="kubernetes/${SERVICE_NAME}"
-
-if [[ -z "${KUBE_ROOT:-}" ]]; then
-  if [[ $# -ge 1 ]]; then
-    KUBE_ROOT="$1"
-  else
-    KUBE_ROOT="$(pwd)"
+function run_command() {
+  if [[ $# -eq 0 ]]; then
+    echo "Usage: run_command cmd arg1 arg2 arg3 ..."
+    exit 1
   fi
-fi
-
-KUBECTL="${KUBE_ROOT}/cluster/kubectl.sh"
-if [[ -z "$(which ${KUBECTL})" ]]; then
-  echo "usage: $0 path/to/kubernetes"
-  exit 1
-fi
+  "$@"
+  if [[ $? -ne 0 ]]; then
+    echo "FAILED to execute: $@"
+    exit 1
+  fi
+}
 
 function stop_kubernetes_service() {
   if [[ $# -ne 2 ]]; then
@@ -78,7 +67,7 @@ function stop_kubernetes_service() {
   local svc_output="$(${KUBECTL} get service | fgrep ${1})"
   if [[ -n "${svc_output}" ]] ; then
     echo "Stopping service ${1}."
-    "${KUBECTL}" stop -f "${2}" > /dev/null 2>&1
+    run_command "${KUBECTL}" stop -f "${2}"
   else
     echo "The service ${1} is not running"
   fi
@@ -93,7 +82,7 @@ function stop_kubernetes_rc() {
   local rc_output="$(${KUBECTL} get rc | fgrep ${1})"
   if [[ -n "${rc_output}" ]] ; then
     echo "Stopping replication controller ${1}."
-    "${KUBECTL}" stop -f "${2}" > /dev/null 2>&1
+    run_command "${KUBECTL}" stop -f "${2}"
   else
     echo "Replication controller ${1} is not running."
   fi
@@ -106,7 +95,7 @@ function start_kubernetes_service() {
   fi
 
   echo "Starting service ${1}."
-  "${KUBECTL}" create -f "${2}" > /dev/null 2>&1
+  run_command "${KUBECTL}" create -f "${2}"
 
   svc_output="$(${KUBECTL} get service | fgrep ${1})"
   if [[ -z "${svc_output}" ]] ; then
@@ -122,7 +111,7 @@ function start_kubernetes_rc() {
   fi
 
   echo "Starting replication controller ${1}."
-  "${KUBECTL}" create -f "${2}" > /dev/null 2>&1
+  run_command "${KUBECTL}" create -f "${2}"
 
   rc_output="$(${KUBECTL} get rc | fgrep ${1})"
   if [[ -z "${rc_output}" ]]; then
@@ -132,19 +121,78 @@ function start_kubernetes_rc() {
 
   # scale the cluster-insight minion controller.
   echo "Scaling replication controller ${1} to ${3} replicas."
-  "${KUBECTL}" scale rc "${1}" --replicas="${3}" > /dev/null 2>&1
+  # The "kubectl scale" command is implemented in newer versions of
+  # Kubernetes.
+  "${KUBECTL}" scale rc "${1}" --replicas="${3}"
+  if [[ $? -ne 0 ]]; then
+    # The "kubectl resize" command is implemented in older versions of
+    # Kubernetes.
+    run_command "${KUBECTL}" resize rc "${1}" --replicas="${3}"
+  fi
 }
 
-function clean_up_directory() {
-  rm -rf "${TMP_DIR}"
+function launch_kubectl_proxy() {
+  local pid
+  for port in $(seq 8001 65535); do 
+    # Start the proxy in the background on port ${port}
+    # The proxy will terminate if this port is already in use.
+    "${KUBECTL}" proxy --port="${port}" > /dev/null 2>&1 & 
+    pid=$!
+    sleep 1
+    if [[ -n $(ps -p "${pid}" -o pid | fgrep -v PID) ]] ; then 
+      # The proxy is running.
+      KUBECTL_PORT=${port}
+      return 0
+    fi
+  done
+
+  # Failed to find a port.
+  KUBECTL_PORT=0
+  return 1
 }
 
-trap clean_up_directory SIGINT SIGTERM SIGHUP EXIT
-mkdir -p "${TMP_DIR}"
+function verify_service_health() {
+  if [[ $# -ne 1 ]]; then
+    echo "Usage: verify_service_health KUBECTL_PORT"
+    exit 1
+  fi
+  for i in $(seq 1 60); do
+    health="$(curl http://localhost:${1}/api/v1beta3/proxy/namespaces/default/services/${SERVICE_NAME}:${SERVICE_PORT}/healthz 2>/dev/null)"
+    if [[ "${health}" =~ "OK" ]]; then
+      return 0
+    fi
+    sleep 1
+  done 
+  return 1
+}
 
-# Extract the project repository to the temporary directory.
-echo "Cloning the Github project repository into ${SERVICE_PATH}."
-git clone "https://github.com/google/${SERVICE_NAME}.git" "${SERVICE_PATH}"
+if [[ ("${1:-}" == "--debug") || ("${1:-}" == "-d") ]]; then
+  # Run in debug mode.
+  # Use the debug version of the master and minion template files.
+  echo "run in debug mode"
+  readonly MASTER_CONTROLLER_FILE="${INSTALL_PATH}/${SERVICE_NAME}-master-controller-debug.yaml"
+  readonly MINION_CONTROLLER_FILE="${INSTALL_PATH}/${SERVICE_NAME}-minion-controller-debug.yaml"
+  shift
+else
+  # Run in production mode.
+  # Use the production version of the master and minion template files.
+  echo "run in production mode"
+  readonly MASTER_CONTROLLER_FILE="${INSTALL_PATH}/${SERVICE_NAME}-master-controller.yaml"
+  readonly MINION_CONTROLLER_FILE="${INSTALL_PATH}/${SERVICE_NAME}-minion-controller.yaml"
+fi
+
+if [[ $# -ge 1 ]]; then
+  KUBE_ROOT="$1"
+  readonly KUBECTL="${KUBE_ROOT}/cluster/kubectl.sh"
+else
+  readonly KUBECTL="kubectl"
+fi
+
+if [[ -z "$(which ${KUBECTL})" ]]; then
+  echo "could not find the kubectl executable at ${KUBECTL}"
+  echo "usage: $0 [-d|--debug] [path/to/kubernetes]"
+  exit 1
+fi
 
 # stop the cluster-insight service and replication controllers.
 stop_kubernetes_service "${SERVICE_NAME}" "${SERVICE_FILE}"
@@ -166,51 +214,22 @@ start_kubernetes_rc "${MINION_CONTROLLER_NAME}" "${MINION_CONTROLLER_FILE}" "${N
 start_kubernetes_rc "${MASTER_CONTROLLER_NAME}" "${MASTER_CONTROLLER_FILE}" "${NUM_MASTERS:-1}"
 start_kubernetes_service "${SERVICE_NAME}" "${SERVICE_FILE}"
 
-KUBECTL_PORT=8001
-KUBECTL_PID=$$
-
-function clean_up_processes() {
-  kill `ps ax | fgrep "kubectl proxy --port=${KUBECTL_PORT}" | awk '{ print $1 }'` > /dev/null 2>&1
-  clean_up_directory
-}
-
-function launch_kubectl_proxy() {
-  for KUBECTL_PORT in `seq 8001 65535`; do 
-    "${KUBECTL}" proxy --port="${KUBECTL_PORT}" > /dev/null 2>&1 & 
-    KUBECTL_PID=$!
-    sleep 1
-    if [[ -n `ps -p "${KUBECTL_PID}" -o pid | fgrep -v PID` ]] ; then 
-      trap clean_up_processes SIGINT SIGTERM SIGHUP EXIT
-      return 0
-    fi
-    port=$((${KUBECTL_PORT} + 1))
-  done
-  return 1
-}
 
 # verify that the cluster-insight service is healthy.
 echo "Verifying service health."
 
+KUBECTL_PORT=0
 launch_kubectl_proxy || {
-  echo "FAILED to run ${KUBECTL} proxy."
+  echo "FAILED to launch ${KUBECTL} proxy."
   exit 1
 }
 
-function verify_service_health() {
-  for i in `seq 1 60`; do
-    health="$(curl http://localhost:${KUBECTL_PORT}/api/v1/proxy/namespaces/default/services/${SERVICE_NAME}:${SERVICE_PORT}/healthz 2>/dev/null)"
-    if [[ "${health}" =~ "OK" ]]; then
-      return 0
-    fi
-    sleep 1
-  done 
-  return 1
-}
+echo "${KUBECTL} proxy is running on port ${KUBECTL_PORT}"
 
-verify_service_health || {
+verify_service_health ${KUBECTL_PORT} || {
   echo "FAILED to get service health response."
   exit 1
 }
 
-echo "Service ${SERVICE_NAME} setup complete."
+echo "Service ${SERVICE_NAME} ALL DONE."
 exit 0

--- a/install/cluster-insight-setup.sh
+++ b/install/cluster-insight-setup.sh
@@ -58,6 +58,11 @@ readonly NUM_MASTERS=1
 readonly SERVICE_FILE="${INSTALL_PATH}/${SERVICE_NAME}-service.yaml"
 readonly DOCKER_IMAGE="kubernetes/${SERVICE_NAME}"
 
+# Run the given command. If the command failed (exits with a non-zero code),
+# print a detailed error message and exit with a non-zero code.
+#
+# Usage:
+# run_command command arg1 arg2 arg3 ...
 function run_command() {
   if [[ $# -eq 0 ]]; then
     echo "Usage: run_command cmd arg1 arg2 arg3 ..."
@@ -169,7 +174,7 @@ function verify_service_health() {
     exit 1
   fi
   for i in $(seq 1 60); do
-    health="$(curl http://localhost:${1}/api/v1beta3/proxy/namespaces/default/services/${SERVICE_NAME}:${SERVICE_PORT}/healthz 2>/dev/null)"
+    health="$(curl http://localhost:${1}/api/v1/proxy/namespaces/default/services/${SERVICE_NAME}:${SERVICE_PORT}/healthz 2>/dev/null)"
     if [[ "${health}" =~ "OK" ]]; then
       return 0
     fi

--- a/install/cluster-insight-setup.sh
+++ b/install/cluster-insight-setup.sh
@@ -23,10 +23,22 @@
 # running on Google Cloud Platform (GCP) and vagrant running Ubuntu 14.04.
 #
 # *** IMPORTANT ***
-# This script must be run from the Kubernetes base directory.
+# This script must be run from directory where you cloned the cluster-insight
+# repository, so ./cluster-insight/install/cluster-insight-setup.sh is
+# the path to the installation script.
 # 
-# To set the number of minions, you should set the env var NUM_MINIONS 
-# or pass the number of minions as a parameter.
+# To explicitly set the number of minions, you should set the environment
+# variable NUM_MINIONS. The default is to set NUM_MINIONS to the number
+# of nodes in your cluster as reported by Kubernetes.
+#
+# You may specify an explicit path to Kubernetes binaries, which is an optional
+# parameter of this script.
+#
+# This script will restart the cluster-insight collector using the latest
+# container pulled from Docker Hub. If you want to restart the collector
+# using the latest binary from each instance (for example, when you build
+# the container from the sources), you should run this script in debug mode
+# by specifying the "-d" or "--debug" as the first argument of this script.
 #
 # The script will print "ALL DONE" if it completed the setup successfully.
 # The script will print "FAILED" in case of a failure.


### PR DESCRIPTION
Also add an explicit debug mode to the setup script, simplify the
setup script, and remove the requirement to provide a path to the
Kubernetes binaries.

Fixes issue #93.