### PR TITLE
The '/elapsed' endpoint shows the elapsed times of Docker/Kubernetes …

### DIFF
--- a/collector/Makefile
+++ b/collector/Makefile
@@ -18,7 +18,7 @@
 # Please read Dockerfile for details on building this service.
 PYTHON="python"
 
-test: test_utilities test_cache test_collector test_docker_proxy
+test: test_utilities test_cache test_collector test_docker_proxy test_global_state
 
 test_cache: simple_cache_test.py
 	$(PYTHON) $^
@@ -30,4 +30,7 @@ test_collector: collector_test.py
 	$(PYTHON) $^
 
 test_docker_proxy: docker_proxy_test.py
+	$(PYTHON) $^
+
+test_global_state: global_state_test.py
 	$(PYTHON) $^

--- a/collector/collector.py
+++ b/collector/collector.py
@@ -79,6 +79,7 @@ def return_elapsed(gs):
         {'start_time': utilities.seconds_to_timestamp(
             elapsed_record.start_time),
          'what': elapsed_record.what,
+         'threadIdentifier': elapsed_record.thread_identifier,
          'elapsed_seconds': duration})
     elapsed_sum += duration
     if (elapsed_min is None) or (elapsed_max is None):

--- a/collector/collector.py
+++ b/collector/collector.py
@@ -57,6 +57,44 @@ def valid_id(x):
   return utilities.valid_optional_string(x)
 
 
+def return_elapsed(gs):
+  """Returns a description of the elapsed time of recent operations.
+
+  Args:
+    gs: global state.
+
+  Returns:
+  A dictionary containing the count, minimum elapsed time,
+  maximum elapsed time, average elapsed time, and list of elapsed time
+  records.
+  """
+  assert isinstance(gs, global_state.GlobalState)
+  elapsed_list = []
+  elapsed_sum = 0.0
+  elapsed_min = None
+  elapsed_max = None
+  for elapsed_record in gs.get_elapsed():
+    duration = elapsed_record.elapsed_seconds
+    elapsed_list.append(
+        {'start_time': utilities.seconds_to_timestamp(
+            elapsed_record.start_time),
+         'what': elapsed_record.what,
+         'elapsed_seconds': duration})
+    elapsed_sum += duration
+    if (elapsed_min is None) or (elapsed_max is None):
+      elapsed_min = duration
+      elapsed_max = duration
+    else:
+      elapsed_min = min(elapsed_min, duration)
+      elapsed_max = max(elapsed_max, duration)
+
+  return {'count': len(elapsed_list),
+          'min': elapsed_min,
+          'max': elapsed_max,
+          'average': elapsed_sum / len(elapsed_list) if elapsed_list else None,
+          'items': elapsed_list}
+
+
 @app.route('/', methods=['GET'])
 def home():
   """Returns the response of the '/' endpoint.
@@ -335,6 +373,26 @@ def get_minions():
     return flask.jsonify(utilities.make_error(msg))
 
   return flask.jsonify(utilities.make_response(minions_status, 'minionsStatus'))
+
+
+@app.route('/elapsed', methods=['GET'])
+def get_elapsed():
+  """Computes the response of the '/elapsed' endpoint.
+
+  Returns:
+  A successful response containing the list of elapsed time records of the
+  most recent Kubernetes and Docker access operations since the previous
+  call to the '/elapsed' endpoint. Never returns more than
+  constants.MAX_ELAPSED_QUEUE_SIZE elapsed time records.
+  """
+  gs = app.context_graph_global_state
+  try:
+    result = return_elapsed(gs)
+    return flask.jsonify(utilities.make_response(result, 'elapsed'))
+  except:
+    msg = 'get_elapsed() failed with exception %s' % sys.exc_info()[0]
+    app.logger.exception(msg)
+    return flask.jsonify(utilities.make_error(msg))
 
 
 @app.route('/healthz', methods=['GET'])

--- a/collector/constants.py
+++ b/collector/constants.py
@@ -44,3 +44,6 @@ MAX_CONCURRENT_COMPUTE_GRAPH = 2
 
 MODE_MINION = 'minion'
 MODE_MASTER = 'master'
+
+# Maximum number of elapsed time records in the elapsed time queue.
+MAX_ELAPSED_QUEUE_SIZE = 1000

--- a/collector/docker.py
+++ b/collector/docker.py
@@ -69,6 +69,7 @@ def fetch_data(gs, url, base_name, expect_missing=False):
   assert isinstance(gs, global_state.GlobalState)
   assert isinstance(url, types.StringTypes)
   assert isinstance(base_name, types.StringTypes)
+  start_time = time.time()
   if gs.get_testing():
     # Read the data from a file.
     fname = 'testdata/' + base_name + '.input.json'
@@ -76,6 +77,7 @@ def fetch_data(gs, url, base_name, expect_missing=False):
       f = open(fname, 'r')
       v = json.loads(f.read())
       f.close()
+      gs.add_elapsed(start_time, fname, time.time() - start_time)
       return v
     except IOError:
       # File not found
@@ -91,7 +93,9 @@ def fetch_data(gs, url, base_name, expect_missing=False):
       raise collector_error.CollectorError(msg)
   else:
     # Send the request to Kubernetes
-    return requests.get(url).json()
+    v = requests.get(url).json()
+    gs.add_elapsed(start_time, url, time.time() - start_time)
+    return v
 
 
 @utilities.global_state_two_string_args

--- a/collector/global_state.py
+++ b/collector/global_state.py
@@ -233,7 +233,7 @@ class GlobalState(object):
     assert utilities.valid_string(url_or_fname)
     assert isinstance(elapsed_seconds, types.FloatType)
 
-    # If the queue is too large, remove some items until its contains less
+    # If the queue is too large, remove some items until it will contain less
     # than constants.MAX_ELAPSED_QUEUE_SIZE elements.
     while self._elapsed_queue.qsize() >= constants.MAX_ELAPSED_QUEUE_SIZE:
       try:

--- a/collector/global_state.py
+++ b/collector/global_state.py
@@ -20,6 +20,7 @@ import collections
 import Queue  # "Queue" was renamed "queue" in Python 3.
 import random
 import sys
+import thread
 import threading
 import types
 
@@ -30,7 +31,8 @@ import utilities
 
 
 ElapsedRecord = collections.namedtuple(
-    'ElapsedRecord', ['start_time', 'what', 'elapsed_seconds'])
+    'ElapsedRecord',
+    ['start_time', 'what', 'thread_identifier', 'elapsed_seconds'])
 
 
 class GlobalState(object):
@@ -245,6 +247,7 @@ class GlobalState(object):
 
     self._elapsed_queue.put(
         ElapsedRecord(start_time=start_time, what=url_or_fname,
+                      thread_identifier=thread.get_ident(),
                       elapsed_seconds=elapsed_seconds))
 
   def get_elapsed(self):

--- a/collector/global_state.py
+++ b/collector/global_state.py
@@ -235,7 +235,7 @@ class GlobalState(object):
     assert utilities.valid_string(url_or_fname)
     assert isinstance(elapsed_seconds, types.FloatType)
 
-    # If the queue is too large, remove some items until it will contain less
+    # If the queue is too large, remove some items until it contains less
     # than constants.MAX_ELAPSED_QUEUE_SIZE elements.
     while self._elapsed_queue.qsize() >= constants.MAX_ELAPSED_QUEUE_SIZE:
       try:

--- a/collector/global_state_test.py
+++ b/collector/global_state_test.py
@@ -17,6 +17,7 @@
 """Tests for collector/global_state.py."""
 
 # global imports
+import thread
 import time
 import types
 import unittest
@@ -46,6 +47,7 @@ class TestGlobalState(unittest.TestCase):
     self.assertEqual(now, result[0].start_time)
     self.assertEqual('abc', result[0].what)
     self.assertEqual(13.4, result[0].elapsed_seconds)
+    self.assertEqual(thread.get_ident(), result[0].thread_identifier)
 
     # Calling get_elapsed() should clear the list of elapsed times.
     result = self._state.get_elapsed()

--- a/collector/global_state_test.py
+++ b/collector/global_state_test.py
@@ -1,0 +1,57 @@
+#!/usr/bin/python
+#
+# Copyright 2015 The Cluster-Insight Authors. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for collector/global_state.py."""
+
+# global imports
+import time
+import types
+import unittest
+
+# local imports
+import global_state
+
+
+class TestGlobalState(unittest.TestCase):
+
+  def setUp(self):
+    self._state = global_state.GlobalState()
+    self._state.init_caches_and_synchronization()
+
+  def test_elapsed(self):
+    result = self._state.get_elapsed()
+    self.assertTrue(isinstance(result, types.ListType))
+    self.assertEqual([], result)
+
+    now = time.time()
+    self._state.add_elapsed(now, 'abc', 13.4)
+
+    # expect to get a list of one elapsed time records.
+    result = self._state.get_elapsed()
+    self.assertTrue(isinstance(result, types.ListType))
+    self.assertEqual(1, len(result))
+    self.assertEqual(now, result[0].start_time)
+    self.assertEqual('abc', result[0].what)
+    self.assertEqual(13.4, result[0].elapsed_seconds)
+
+    # Calling get_elapsed() should clear the list of elapsed times.
+    result = self._state.get_elapsed()
+    self.assertTrue(isinstance(result, types.ListType))
+    self.assertEqual([], result)
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/collector/static/home.html
+++ b/collector/static/home.html
@@ -55,6 +55,9 @@ limitations under the License.
         <tr> <td><a href=/minions_status>/minions_status</a></td>
              <td>Status of the Cluster-Insight minions in this cluster (JSON)
              </td></tr>
+        <tr> <td><a href=/elapsed>/elapsed</a></td>
+             <td>List of recent Kubernets/Docker access times (JSON)
+             </td></tr>
         <tr> <td><a href=/healthz>/healthz</a></td>
              <td>A health check response (JSON)</td></tr>
     </table>


### PR DESCRIPTION
…calls since the previous access to this endpoint.

This endpoint should help to find performance problems which increase the
overall response time. See issue #82.