### PR TITLE
Don't set up a load balancer.

### DIFF
--- a/install/cluster-insight-service.yaml
+++ b/install/cluster-insight-service.yaml
@@ -8,7 +8,6 @@ metadata:
     kubernetes.io/name: ClusterInsight
     version: v1
 spec: 
-  type: LoadBalancer
   selector: 
     cluster-insight-mode: master
   ports: 


### PR DESCRIPTION
Let's not make it too easy to accidentally expose the Cluster Insight API publicly.