### PR TITLE
Remove some API resources in preparation for dropping use of the Docker API.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # Ignore following files
 *.pyc
+**/.DS_Store

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -11,3 +11,4 @@
 Eran Gabber <eran@google.com>
 Vas Bala <vasbala@google.com>
 Jack Greenfield <jackgr@google.com>
+Ken Rimey <rimey@google.com>

--- a/collector/collector.py
+++ b/collector/collector.py
@@ -42,21 +42,6 @@ app = flask.Flask(__name__)
 cors = CORS(app)
 
 
-def valid_id(x):
-  """Tests whether 'x' a valid resource identifier.
-
-  A valid resource identifier is either None (which means you refer to every
-  resource) or a non-empty string.
-
-  Args:
-    x: a resource identifier or None.
-
-  Returns:
-    True iff 'x' is a valid resource identifier.
-  """
-  return utilities.valid_optional_string(x)
-
-
 def return_elapsed(gs):
   """Returns a description of the elapsed time of recent operations.
 

--- a/collector/collector.py
+++ b/collector/collector.py
@@ -103,10 +103,6 @@ def get_nodes():
     nodes_list = kubernetes.get_nodes_with_metrics(gs)
   except collector_error.CollectorError as e:
     return flask.jsonify(utilities.make_error(str(e)))
-  except:
-    msg = 'kubernetes.get_nodes() failed with exception %s' % sys.exc_info()[0]
-    app.logger.exception(msg)
-    return flask.jsonify(utilities.make_error(msg))
 
   return flask.jsonify(utilities.make_response(nodes_list, 'resources'))
 
@@ -123,11 +119,6 @@ def get_services():
     services_list = kubernetes.get_services(gs)
   except collector_error.CollectorError as e:
     return flask.jsonify(utilities.make_error(str(e)))
-  except:
-    msg = ('kubernetes.get_services() failed with exception %s' %
-           sys.exc_info()[0])
-    app.logger.exception(msg)
-    return flask.jsonify(utilities.make_error(msg))
 
   return flask.jsonify(utilities.make_response(services_list, 'resources'))
 
@@ -144,11 +135,6 @@ def get_rcontrollers():
     rcontrollers_list = kubernetes.get_rcontrollers(gs)
   except collector_error.CollectorError as e:
     return flask.jsonify(utilities.make_error(str(e)))
-  except:
-    msg = ('kubernetes.get_rcontrollers() failed with exception %s' %
-           sys.exc_info()[0])
-    app.logger.exception(msg)
-    return flask.jsonify(utilities.make_error(msg))
 
   return flask.jsonify(utilities.make_response(rcontrollers_list, 'resources'))
 
@@ -165,10 +151,6 @@ def get_pods():
     pods_list = kubernetes.get_pods(gs, None)
   except collector_error.CollectorError as e:
     return flask.jsonify(utilities.make_error(str(e)))
-  except:
-    msg = 'kubernetes.get_pods() failed with exception %s' % sys.exc_info()[0]
-    app.logger.exception(msg)
-    return flask.jsonify(utilities.make_error(msg))
 
   return flask.jsonify(utilities.make_response(pods_list, 'resources'))
 
@@ -191,10 +173,6 @@ def get_containers():
 
   except collector_error.CollectorError as e:
     return flask.jsonify(utilities.make_error(str(e)))
-  except:
-    msg = 'get_containers() failed with exception %s' % sys.exc_info()[0]
-    app.logger.exception(msg)
-    return flask.jsonify(utilities.make_error(msg))
 
   return flask.jsonify(utilities.make_response(containers, 'resources'))
 
@@ -219,10 +197,6 @@ def get_processes():
 
   except collector_error.CollectorError as e:
     return flask.jsonify(utilities.make_error(str(e)))
-  except:
-    msg = 'get_processes() failed with exception %s' % sys.exc_info()[0]
-    app.logger.exception(msg)
-    return flask.jsonify(utilities.make_error(msg))
 
   return flask.jsonify(utilities.make_response(processes, 'resources'))
 
@@ -247,10 +221,6 @@ def get_images():
 
   except collector_error.CollectorError as e:
     return flask.jsonify(utilities.make_error(str(e)))
-  except:
-    msg = 'kubernetes.get_images() failed with exception %s' % sys.exc_info()[0]
-    app.logger.exception(msg)
-    return flask.jsonify(utilities.make_error(msg))
 
   # The images list is sorted by increasing identifiers.
   images_list = [images_dict[key] for key in sorted(images_dict.keys())]
@@ -269,11 +239,6 @@ def get_debug():
     return context.compute_graph(gs, 'dot')
   except collector_error.CollectorError as e:
     return flask.jsonify(utilities.make_error(str(e)))
-  except:
-    msg = ('compute_graph(\"dot\") failed with exception %s' %
-           sys.exc_info()[0])
-    app.logger.exception(msg)
-    return flask.jsonify(utilities.make_error(msg))
 
 
 @app.route('/cluster/resources', methods=['GET'])
@@ -289,11 +254,6 @@ def get_resources():
     return flask.jsonify(response)
   except collector_error.CollectorError as e:
     return flask.jsonify(utilities.make_error(str(e)))
-  except:
-    msg = ('compute_graph(\"resources\") failed with exception %s' %
-           sys.exc_info()[0])
-    app.logger.exception(msg)
-    return flask.jsonify(utilities.make_error(msg))
 
 
 @app.route('/cluster', methods=['GET'])
@@ -309,11 +269,6 @@ def get_cluster():
     return flask.jsonify(response)
   except collector_error.CollectorError as e:
     return flask.jsonify(utilities.make_error(str(e)))
-  except:
-    msg = ('compute_graph(\"context_graph\") failed with exception %s' %
-           sys.exc_info()[0])
-    app.logger.exception(msg)
-    return flask.jsonify(utilities.make_error(msg))
 
 
 @app.route('/version', methods=['GET'])
@@ -329,10 +284,6 @@ def get_version():
     return flask.jsonify(utilities.make_response(version, 'version'))
   except collector_error.CollectorError as e:
     return flask.jsonify(utilities.make_error(str(e)))
-  except:
-    msg = 'get_version() failed with exception %s' % sys.exc_info()[0]
-    app.logger.exception(msg)
-    return flask.jsonify(utilities.make_error(msg))
 
 
 @app.route('/minions_status', methods=['GET'])
@@ -353,10 +304,6 @@ def get_minions():
 
   except collector_error.CollectorError as e:
     return flask.jsonify(utilities.make_error(str(e)))
-  except:
-    msg = 'get_minions_status() failed with exception %s' % sys.exc_info()[0]
-    app.logger.exception(msg)
-    return flask.jsonify(utilities.make_error(msg))
 
   return flask.jsonify(utilities.make_response(minions_status, 'minionsStatus'))
 
@@ -372,13 +319,8 @@ def get_elapsed():
   constants.MAX_ELAPSED_QUEUE_SIZE elapsed time records.
   """
   gs = app.context_graph_global_state
-  try:
-    result = return_elapsed(gs)
-    return flask.jsonify(utilities.make_response(result, 'elapsed'))
-  except:
-    msg = 'get_elapsed() failed with exception %s' % sys.exc_info()[0]
-    app.logger.exception(msg)
-    return flask.jsonify(utilities.make_error(msg))
+  result = return_elapsed(gs)
+  return flask.jsonify(utilities.make_response(result, 'elapsed'))
 
 
 @app.route('/healthz', methods=['GET'])

--- a/collector/collector_test.py
+++ b/collector/collector_test.py
@@ -131,18 +131,6 @@ class TestCollector(unittest.TestCase):
     ret_value = self.app.get('/cluster/resources/rcontrollers')
     self.compare_to_golden(ret_value.data, 'replicationcontrollers')
 
-  def test_containers(self):
-    ret_value = self.app.get('/cluster/resources/containers')
-    self.compare_to_golden(ret_value.data, 'containers')
-
-  def test_processes(self):
-    ret_value = self.app.get('/cluster/resources/processes')
-    self.compare_to_golden(ret_value.data, 'processes')
-
-  def test_images(self):
-    ret_value = self.app.get('/cluster/resources/images')
-    self.compare_to_golden(ret_value.data, 'images')
-
   def count_resources(self, output, type_name):
     assert isinstance(output, types.DictType)
     assert isinstance(type_name, types.StringTypes)
@@ -334,28 +322,6 @@ class TestCollector(unittest.TestCase):
     ret_value = self.app.get('/debug')
     self.compare_to_golden(ret_value.data, 'debug')
 
-  def test_version(self):
-    """Test the '/version' endpoint."""
-    ret_value = self.app.get('/version')
-    result = json.loads(ret_value.data)
-    self.assertTrue(result.get('success'))
-    version = result.get('version')
-    self.assertTrue(isinstance(version, types.StringTypes))
-    self.assertEqual(
-        'kubernetes/cluster-insight ac933439ec5a 2015-03-28T17:23:41', version)
-
-  def test_minions_status(self):
-    """Test the '/minions_status' endpoint."""
-    ret_value = self.app.get('/minions_status')
-    result = json.loads(ret_value.data)
-    self.assertTrue(result.get('success'))
-    status = result.get('minionsStatus')
-    self.assertTrue(isinstance(status, types.DictType))
-    self.assertEqual(
-        '{"k8s-guestbook-node-1": "OK", "k8s-guestbook-node-2": "OK", '
-        '"k8s-guestbook-node-3": "OK", "k8s-guestbook-node-4": "ERROR"}',
-        json.dumps(status, sort_keys=True))
-
   def verify_empty_elapsed(self):
     """Verify that '/elapsed' endoint returns an empty list of elapsed times.
     """
@@ -372,14 +338,16 @@ class TestCollector(unittest.TestCase):
     self.assertEqual([], elapsed.get('items'))
 
   def test_elapsed(self):
-    """Test the '/elapsed' endpoint with and without calls to Kubernetes/Docker.
+    """Test the '/elapsed' endpoint with and without calls to Kubernetes.
     """
     self.verify_empty_elapsed()
 
-    # Issue a few requests to Kubernetes and Docker.
-    self.app.get('/version')
+    # Issue a few requests to Kubernetes.
+    self.app.get('/cluster/resources/nodes')
+    self.app.get('/cluster/resources/services')
+    self.app.get('/cluster/resources/rcontrollers')
 
-    # Now we should have a few elpased time records.
+    # Now we should have a few elapsed time records.
     ret_value = self.app.get('/elapsed')
     result = json.loads(ret_value.data)
     self.assertTrue(result.get('success'))

--- a/collector/collector_test.py
+++ b/collector/collector_test.py
@@ -47,6 +47,7 @@ class TestCollector(unittest.TestCase):
     gs.set_logger(collector.app.logger)
     gs.set_num_workers(1)  # execute worker tasks sequentially
     collector.app.context_graph_global_state = gs
+    collector.app.config['TESTING'] = True
     self.app = collector.app.test_client()
 
   def compare_to_golden(self, ret_value, fname):

--- a/collector/kubernetes.py
+++ b/collector/kubernetes.py
@@ -388,37 +388,6 @@ def get_selected_pods(gs, selector):
   return pods
 
 
-@utilities.global_state_string_args
-def get_pod_host(gs, pod_id):
-  """Gets the host name associated with the given pod.
-
-  Args:
-    gs: global state.
-    pod_id: the pod name.
-
-  Returns:
-    If the pod was found, returns the associated host name.
-    If the pod was not found, returns an empty string.
-
-  Raises:
-    CollectorError in case of failure to fetch data from Kubernetes.
-    Other exceptions may be raised due to exectution errors.
-  """
-  gs.logger_info('calling get_pod_host(pod_id=%s)', pod_id)
-  for pod in get_pods(gs):
-    if not utilities.valid_string(pod.get('id')):
-      # Found an invalid pod without a pod ID.
-      continue
-
-    pod_host = utilities.get_attribute(pod, ['properties', 'spec', 'nodeName'])
-    if pod['id'] == pod_id and utilities.valid_string(pod_host):
-      # 'pod_host' may be missing if the pod is in "Waiting" state.
-      return pod_host
-
-  # Could not find pod.
-  return ''
-
-
 @utilities.global_state_arg
 def get_services(gs):
   """Gets the list of services in the current cluster.

--- a/collector/static/home.html
+++ b/collector/static/home.html
@@ -40,23 +40,12 @@ limitations under the License.
              <td>State of all Kubernetes services (JSON)</td> </tr>
         <tr> <td><a href=/cluster/resources/rcontrollers>/cluster/resources/rcontrollers</a></td>
              <td>State of all Kubernetes replication controllers (JSON)</td> </tr>
-        <tr> <td><a href=/cluster/resources/containers>/cluster/resources/containers</a></td>
-             <td>State of all Docker containers (JSON)</td> </tr>
-        <tr> <td><a href=/cluster/resources/processes>/cluster/resources/processes</a></td>
-             <td>State of all Docker processes (JSON)</td> </tr>
-        <tr> <td><a href=/cluster/resources/images>/cluster/resources/images</a></td>
-             <td>State of all Docker images (JSON)</td> </tr>
         <tr> <td><a href=/debug>/debug</a></td>
              <td>The contents of /graph in DOT format
                  (<a href=http://en.wikipedia.org/wiki/DOT_%28graph_description_language%29>DOT</a>)
              </td> </tr>
-        <tr> <td><a href=/version>/version</a></td>
-             <td>The version of the running image (JSON)</td></tr>
-        <tr> <td><a href=/minions_status>/minions_status</a></td>
-             <td>Status of the Cluster-Insight minions in this cluster (JSON)
-             </td></tr>
         <tr> <td><a href=/elapsed>/elapsed</a></td>
-             <td>List of recent Kubernets/Docker access times (JSON)
+             <td>List of recent Kubernetes access times (JSON)
              </td></tr>
         <tr> <td><a href=/healthz>/healthz</a></td>
              <td>A health check response (JSON)</td></tr>


### PR DESCRIPTION
This is a first batch of commits to make the collector depend only on the Kubernetes API, and not the Docker API. Please see the individual commit messages for the details.