### PR TITLE
Remove worker thread pool.

### DIFF
--- a/collector/collector.py
+++ b/collector/collector.py
@@ -234,18 +234,12 @@ def main():
   parser.add_argument('-p', '--port', action='store', type=int,
                       default=constants.DATA_COLLECTOR_PORT,
                       help='data collector port number [default=%(default)d]')
-  parser.add_argument('-w', '--workers', action='store', type=int,
-                      default=0,
-                      help=('number of concurrent workers. A zero or a '
-                            'negative value denotes an automatic calculation '
-                            'of this number. [default=%(default)d]'))
   args = parser.parse_args()
 
   app.logger.setLevel(logging.DEBUG if args.debug else logging.INFO)
   g_state = global_state.GlobalState()
   g_state.init_caches_and_synchronization()
   g_state.set_logger(app.logger)
-  g_state.set_num_workers(args.workers)
   app.context_graph_global_state = g_state
 
   app.run(host=args.host, port=args.port, debug=args.debug)

--- a/collector/collector_test.py
+++ b/collector/collector_test.py
@@ -45,7 +45,6 @@ class TestCollector(unittest.TestCase):
     gs.init_caches_and_synchronization()
     gs.set_testing(True)
     gs.set_logger(collector.app.logger)
-    gs.set_num_workers(1)  # execute worker tasks sequentially
     collector.app.context_graph_global_state = gs
     collector.app.config['TESTING'] = True
     self.app = collector.app.test_client()

--- a/collector/constants.py
+++ b/collector/constants.py
@@ -27,16 +27,7 @@ MAX_CACHED_DATA_AGE_SECONDS = 10
 # cache.
 CACHE_DATA_CLEANUP_AGE_SECONDS = 3600  # one hour
 
-# Low and high bounds of the number of concurrent worker threads that
-# fetch information from the backend.
-# The number of workers threads may either be set by a flag or set to be
-# the number of nodes in the cluster.
-MIN_CONCURRENT_WORKERS = 2
-MAX_CONCURRENT_WORKERS = 10
-
 # Maximum number of active context.compute_graph() calls.
-# These calls are executed by concurrent worker threads, so they may generate
-# heavy load on the backend.
 MAX_CONCURRENT_COMPUTE_GRAPH = 2
 
 # Maximum number of elapsed time records in the elapsed time queue.

--- a/collector/global_state.py
+++ b/collector/global_state.py
@@ -18,7 +18,6 @@
 """
 import collections
 import Queue  # "Queue" was renamed "queue" in Python 3.
-import random
 import sys
 import thread
 import threading
@@ -58,17 +57,10 @@ class GlobalState(object):
   def __init__(self):
     """Initialize internal state."""
     self._testing = False
-    self._num_workers = 0
 
     # '_logger_lock' protects concurrent logging operations.
     self._logger_lock = threading.Lock()
     self._logger = None
-
-    # '_random_lock' protects concurrent calls to get_random_priority().
-    self._random_lock = threading.Lock()
-    self._random_generator = random.Random()
-    self._random_generator.seed(None)  # use system time
-    self._sequence_number = 0
 
     # pointers to various caches.
     self._nodes_cache = None
@@ -124,29 +116,6 @@ class GlobalState(object):
 
   def get_testing(self):
     return self._testing
-
-  def set_num_workers(self, workers):
-    assert isinstance(workers, types.IntType)
-    self._num_workers = workers
-
-  def get_num_workers(self):
-    return self._num_workers
-
-  def get_random_priority(self):
-    """Computes a presudo random priority in production mode.
-
-    When in testing mode, return an increasing sequence number.
-
-    Returns:
-    A pseudo random priority in the range [0, 1000] or an increasing
-    sequence number depending on production/testing mode, respectively.
-    """
-    with self._random_lock:
-      if self._testing:
-        self._sequence_number += 1
-        return self._sequence_number
-      else:
-        return self._random_generator.randint(0, 1000)
 
   def set_logger(self, logger):
     with self._logger_lock:

--- a/collector/utilities.py
+++ b/collector/utilities.py
@@ -161,29 +161,6 @@ def two_dict_args(func):
   return inner
 
 
-def range_limit(x, low, high):
-  """Limits the input value 'x' to the range [low, high].
-
-  Args:
-    x: the input value. should be compatible with the values of 'low' and
-      'high'.
-    low: low limit on the output value.
-    high: high limit on the output value.
-
-  Returns:
-  If 'x' is less than 'low', returns 'low'.
-  If 'x' is greater than 'high', returns 'high'.
-  Otherwise, returns 'x'.
-  """
-  assert low <= high
-  if x < low:
-    return low
-  elif x > high:
-    return high
-  else:
-    return x
-
-
 def wrap_object(obj, obj_type, obj_id, timestamp, label=None,
                 alt_label=None):
   """Returns a dictionary containing the standard wrapper around 'obj'.


### PR DESCRIPTION
There's no need for the extra concurrency now that we're only pulling data
from the Kubernetes API.