### PR TITLE
Use built-in type names instead of the types module.

### DIFF
--- a/collector/collector_test.py
+++ b/collector/collector_test.py
@@ -131,9 +131,9 @@ class TestCollector(unittest.TestCase):
     self.compare_to_golden(ret_value.data, 'replicationcontrollers')
 
   def count_resources(self, output, type_name):
-    assert isinstance(output, types.DictType)
+    assert isinstance(output, dict)
     assert isinstance(type_name, types.StringTypes)
-    if not isinstance(output.get('resources'), types.ListType):
+    if not isinstance(output.get('resources'), list):
       return 0
 
     n = 0
@@ -151,14 +151,14 @@ class TestCollector(unittest.TestCase):
     If the source type and/or target type is specified (e.g., "Node", "Pod",
     etc.), count only relations that additionally match that constraint.
     """
-    assert isinstance(output, types.DictType)
+    assert isinstance(output, dict)
     assert isinstance(type_name, types.StringTypes)
-    if not isinstance(output.get('relations'), types.ListType):
+    if not isinstance(output.get('relations'), list):
       return 0
 
     n = 0
     for r in output.get('relations'):
-      assert isinstance(r, types.DictType)
+      assert isinstance(r, dict)
       if r['type'] != type_name:
         continue
       if source_type and r['source'].split(':')[0] != source_type:
@@ -170,7 +170,7 @@ class TestCollector(unittest.TestCase):
     return n
 
   def verify_resources(self, result, start_time, end_time):
-    assert isinstance(result, types.DictType)
+    assert isinstance(result, dict)
     assert utilities.valid_string(start_time)
     assert utilities.valid_string(end_time)
     self.assertEqual(1, self.count_resources(result, 'Cluster'))
@@ -184,7 +184,7 @@ class TestCollector(unittest.TestCase):
     self.assertEqual(3, self.count_resources(result, 'ReplicationController'))
 
     # Verify that all resources are valid wrapped objects.
-    assert isinstance(result.get('resources'), types.ListType)
+    assert isinstance(result.get('resources'), list)
     for r in result['resources']:
       # all resources must be valid.
       assert utilities.is_wrapped_object(r)
@@ -245,9 +245,9 @@ class TestCollector(unittest.TestCase):
 
       # Verify that all relations contain a timestamp in the range
       # [start_time, end_time].
-      self.assertTrue(isinstance(result.get('relations'), types.ListType))
+      self.assertTrue(isinstance(result.get('relations'), list))
       for r in result['relations']:
-        self.assertTrue(isinstance(r, types.DictType))
+        self.assertTrue(isinstance(r, dict))
         timestamp = r.get('timestamp')
         self.assertTrue(utilities.valid_string(timestamp))
         self.assertTrue(start_time <= timestamp <= end_time)
@@ -265,7 +265,7 @@ class TestCollector(unittest.TestCase):
     timestamp_before_update = utilities.now()
     gs = collector.app.context_graph_global_state
     nodes, timestamp_seconds = gs.get_nodes_cache().lookup('')
-    self.assertTrue(isinstance(nodes, types.ListType))
+    self.assertTrue(isinstance(nodes, list))
     self.assertTrue(start_time <=
                     utilities.seconds_to_timestamp(timestamp_seconds) <=
                     end_time)
@@ -291,9 +291,9 @@ class TestCollector(unittest.TestCase):
 
     # Verify that all relations contain a timestamp in the range
     # [start_time, end_time].
-    self.assertTrue(isinstance(result.get('relations'), types.ListType))
+    self.assertTrue(isinstance(result.get('relations'), list))
     for r in result['relations']:
-      self.assertTrue(isinstance(r, types.DictType))
+      self.assertTrue(isinstance(r, dict))
       timestamp = r.get('timestamp')
       self.assertTrue(utilities.valid_string(timestamp))
       self.assertTrue(start_time <= timestamp <= end_time)
@@ -315,12 +315,12 @@ class TestCollector(unittest.TestCase):
     result = json.loads(ret_value.data)
     self.assertTrue(result.get('success'))
     elapsed = result.get('elapsed')
-    self.assertTrue(isinstance(elapsed, types.DictType))
+    self.assertTrue(isinstance(elapsed, dict))
     self.assertEqual(0, elapsed.get('count'))
     self.assertTrue(elapsed.get('min') is None)
     self.assertTrue(elapsed.get('max') is None)
     self.assertTrue(elapsed.get('average') is None)
-    self.assertTrue(isinstance(elapsed.get('items'), types.ListType))
+    self.assertTrue(isinstance(elapsed.get('items'), list))
     self.assertEqual([], elapsed.get('items'))
 
   def test_elapsed(self):
@@ -338,13 +338,13 @@ class TestCollector(unittest.TestCase):
     result = json.loads(ret_value.data)
     self.assertTrue(result.get('success'))
     elapsed = result.get('elapsed')
-    self.assertTrue(isinstance(elapsed, types.DictType))
+    self.assertTrue(isinstance(elapsed, dict))
     self.assertEqual(3, elapsed.get('count'))
     self.assertTrue(elapsed.get('min') > 0)
     self.assertTrue(elapsed.get('max') > 0)
     self.assertTrue(elapsed.get('min') <= elapsed.get('average') <=
                     elapsed.get('max'))
-    self.assertTrue(isinstance(elapsed.get('items'), types.ListType))
+    self.assertTrue(isinstance(elapsed.get('items'), list))
     self.assertEqual(3, len(elapsed.get('items')))
 
     # The next call to '/elapsed' should return an empty list

--- a/collector/context.py
+++ b/collector/context.py
@@ -82,7 +82,7 @@ class ContextGraph(object):
       return self._current_relations_to_timestamps
 
   def set_relations_to_timestamps(self, d):
-    assert isinstance(d, types.DictType)
+    assert isinstance(d, dict)
     with self._lock:
       self._previous_relations_to_timestamps = d
 
@@ -93,7 +93,7 @@ class ContextGraph(object):
         annotations, ['label']))
     assert utilities.valid_string(rtype)
     assert utilities.valid_string(timestamp)
-    assert isinstance(obj, types.DictType)
+    assert isinstance(obj, dict)
 
     with self._lock:
       # It is possible that the same resource is referenced by more than one
@@ -119,7 +119,7 @@ class ContextGraph(object):
     assert utilities.valid_string(source) and utilities.valid_string(target)
     assert utilities.valid_string(kind)
     assert utilities.valid_optional_string(label)
-    assert (metadata is None) or isinstance(metadata, types.DictType)
+    assert (metadata is None) or isinstance(metadata, dict)
 
     with self._lock:
       # The timestamp of the relation should be inherited from the previous
@@ -366,7 +366,7 @@ def _do_compute_service(gs, cluster_guid, service, g):
   selector = utilities.get_attribute(
       service, ['properties', 'spec', 'selector'])
   if selector:
-    if not isinstance(selector, types.DictType):
+    if not isinstance(selector, dict):
       msg = 'Service id=%s has an invalid "selector" value' % service_id
       gs.logger_error(msg)
       raise collector_error.CollectorError(msg)
@@ -398,7 +398,7 @@ def _do_compute_rcontroller(gs, cluster_guid, rcontroller, g):
   selector = utilities.get_attribute(
       rcontroller, ['properties', 'spec', 'selector'])
   if selector:
-    if not isinstance(selector, types.DictType):
+    if not isinstance(selector, dict):
       msg = ('Rcontroller id=%s has an invalid "replicaSelector" value' %
              rcontroller_id)
       gs.logger_error(msg)
@@ -429,7 +429,7 @@ def _do_compute_other_nodes(gs, cluster_guid, nodes_list, oldest_timestamp, g):
   """
   assert isinstance(gs, global_state.GlobalState)
   assert utilities.valid_string(cluster_guid)
-  assert isinstance(nodes_list, types.ListType)
+  assert isinstance(nodes_list, list)
   assert utilities.valid_string(oldest_timestamp)
   assert isinstance(g, ContextGraph)
 

--- a/collector/global_state.py
+++ b/collector/global_state.py
@@ -21,7 +21,6 @@ import Queue  # "Queue" was renamed "queue" in Python 3.
 import sys
 import thread
 import threading
-import types
 
 # local imports
 import constants
@@ -150,7 +149,7 @@ class GlobalState(object):
       return self._relations_to_timestamps
 
   def set_relations_to_timestamps(self, v):
-    assert isinstance(v, types.DictType)
+    assert isinstance(v, dict)
     with self._relations_lock:
       self._relations_to_timestamps = v
 
@@ -165,9 +164,9 @@ class GlobalState(object):
       url_or_fname: the URL or file name of the operation.
       elapsed_seconds: the elapsed time of the operation.
     """
-    assert isinstance(start_time, types.FloatType)
+    assert isinstance(start_time, float)
     assert utilities.valid_string(url_or_fname)
-    assert isinstance(elapsed_seconds, types.FloatType)
+    assert isinstance(elapsed_seconds, float)
 
     # If the queue is too large, remove some items until it contains less
     # than constants.MAX_ELAPSED_QUEUE_SIZE elements.

--- a/collector/global_state_test.py
+++ b/collector/global_state_test.py
@@ -19,7 +19,6 @@
 # global imports
 import thread
 import time
-import types
 import unittest
 
 # local imports
@@ -34,7 +33,7 @@ class TestGlobalState(unittest.TestCase):
 
   def test_elapsed(self):
     result = self._state.get_elapsed()
-    self.assertTrue(isinstance(result, types.ListType))
+    self.assertTrue(isinstance(result, list))
     self.assertEqual([], result)
 
     now = time.time()
@@ -42,7 +41,7 @@ class TestGlobalState(unittest.TestCase):
 
     # expect to get a list of one elapsed time records.
     result = self._state.get_elapsed()
-    self.assertTrue(isinstance(result, types.ListType))
+    self.assertTrue(isinstance(result, list))
     self.assertEqual(1, len(result))
     self.assertEqual(now, result[0].start_time)
     self.assertEqual('abc', result[0].what)
@@ -51,7 +50,7 @@ class TestGlobalState(unittest.TestCase):
 
     # Calling get_elapsed() should clear the list of elapsed times.
     result = self._state.get_elapsed()
-    self.assertTrue(isinstance(result, types.ListType))
+    self.assertTrue(isinstance(result, list))
     self.assertEqual([], result)
 
 

--- a/collector/kubernetes.py
+++ b/collector/kubernetes.py
@@ -25,7 +25,6 @@ import json
 import os
 import sys
 import time
-import types
 
 import requests
 
@@ -187,7 +186,7 @@ def get_nodes(gs):
     raise collector_error.CollectorError(msg)
 
   now = time.time()
-  if not (isinstance(result, types.DictType) and 'items' in result):
+  if not (isinstance(result, dict) and 'items' in result):
     msg = 'invalid result when fetching %s' % url
     gs.logger_exception(msg)
     raise collector_error.CollectorError(msg)
@@ -266,7 +265,7 @@ def get_pods(gs):
     raise collector_error.CollectorError(msg)
 
   now = time.time()
-  if not (isinstance(result, types.DictType) and 'items' in result):
+  if not (isinstance(result, dict) and 'items' in result):
     msg = 'invalid result when fetching %s' % url
     gs.logger_exception(msg)
     raise collector_error.CollectorError(msg)
@@ -346,7 +345,7 @@ def matching_labels(pod, selector):
   """
   pod_labels = utilities.get_attribute(
       pod, ['properties', 'metadata', 'labels'])
-  if not isinstance(pod_labels, types.DictType):
+  if not isinstance(pod_labels, dict):
     return False
   selector_view = selector.viewitems()
   pod_labels_view = pod_labels.viewitems()
@@ -427,7 +426,7 @@ def get_services(gs):
     raise collector_error.CollectorError(msg)
 
   now = time.time()
-  if not (isinstance(result, types.DictType) and 'items' in result):
+  if not (isinstance(result, dict) and 'items' in result):
     msg = 'invalid result when fetching %s' % url
     gs.logger_exception(msg)
     raise collector_error.CollectorError(msg)
@@ -479,7 +478,7 @@ def get_rcontrollers(gs):
     raise collector_error.CollectorError(msg)
 
   now = time.time()
-  if not (isinstance(result, types.DictType) and 'items' in result):
+  if not (isinstance(result, dict) and 'items' in result):
     msg = 'invalid result when fetching %s' % url
     gs.logger_exception(msg)
     raise collector_error.CollectorError(msg)

--- a/collector/metrics.py
+++ b/collector/metrics.py
@@ -25,7 +25,6 @@ https://github.com/GoogleCloudPlatform/heapster/issues/241.
 
 # global imports
 import copy
-import types
 
 # local imports
 import utilities
@@ -135,7 +134,7 @@ def _make_gcm_metrics(project_id, labels_dict):
     return None
 
   assert utilities.valid_string(project_id)
-  assert isinstance(labels_dict, types.DictType)
+  assert isinstance(labels_dict, dict)
 
   if not labels_dict:
     # an empty dictionary

--- a/collector/simple_cache.py
+++ b/collector/simple_cache.py
@@ -89,12 +89,12 @@ class SimpleCache(object):
   """
 
   def __init__(self, max_data_age_seconds, data_cleanup_age_seconds):
-    assert (isinstance(max_data_age_seconds, types.IntType) or
-            isinstance(max_data_age_seconds, types.LongType) or
-            isinstance(max_data_age_seconds, types.FloatType))
-    assert (isinstance(data_cleanup_age_seconds, types.IntType) or
-            isinstance(data_cleanup_age_seconds, types.LongType) or
-            isinstance(data_cleanup_age_seconds, types.FloatType))
+    assert (isinstance(max_data_age_seconds, int) or
+            isinstance(max_data_age_seconds, long) or
+            isinstance(max_data_age_seconds, float))
+    assert (isinstance(data_cleanup_age_seconds, int) or
+            isinstance(data_cleanup_age_seconds, long) or
+            isinstance(data_cleanup_age_seconds, float))
     assert max_data_age_seconds >= 0
     assert data_cleanup_age_seconds >= 0
     assert data_cleanup_age_seconds >= max_data_age_seconds
@@ -116,7 +116,7 @@ class SimpleCache(object):
     Args:
       now: current time in seconds since the Epoch.
     """
-    assert isinstance(now, types.FloatType)
+    assert isinstance(now, float)
     threshold = now - self._data_cleanup_age_seconds
     # Scan the cache using a list of keys instead of iterating on the cache
     # directly because we are deleting elements from the cache while iterating.
@@ -142,7 +142,7 @@ class SimpleCache(object):
     returns the tuple (None, None).
     """
     assert isinstance(label, types.StringTypes)
-    assert (now is None) or isinstance(now, types.FloatType)
+    assert (now is None) or isinstance(now, float)
 
     self._lock.acquire()
     ts_seconds = time.time() if now is None else now
@@ -189,7 +189,7 @@ class SimpleCache(object):
     assert isinstance(label, types.StringTypes)
     assert value is not None
     assert ((update_timestamp is None) or
-            isinstance(update_timestamp, types.FloatType))
+            isinstance(update_timestamp, float))
 
     self._lock.acquire()
     # Cleanup only when inserting new values into the cache in order to

--- a/collector/simple_cache_test.py
+++ b/collector/simple_cache_test.py
@@ -102,7 +102,7 @@ class TestSimpleCache(unittest.TestCase):
     Returns:
     The string 'id' followed by the string representation of the number 'i'.
     """
-    assert isinstance(i, types.IntType)
+    assert isinstance(i, int)
     return {'id': 'id%d' % i}
 
   def test_cleanup(self):
@@ -141,7 +141,7 @@ class TestSimpleCache(unittest.TestCase):
     A dictionary containing 'id', 'timestamp', and 'value' key/value pairs.
     """
     assert isinstance(name, types.StringTypes)
-    assert isinstance(timestamp_seconds, types.FloatType)
+    assert isinstance(timestamp_seconds, float)
     return {'id': name,
             'timestamp': utilities.seconds_to_timestamp(timestamp_seconds),
             'value': value}
@@ -226,7 +226,7 @@ class TestSimpleCache(unittest.TestCase):
     Returns:
     A wrapped Node object with the given 'timestamp' and 'lastHeartbeatTime'.
     """
-    assert isinstance(seconds, (types.IntType, types.LongType, types.FloatType))
+    assert isinstance(seconds, (int, long, float))
     return utilities.wrap_object(
         {'uid': KEY,
          'lastHeartbeatTime': utilities.seconds_to_timestamp(seconds)},
@@ -271,7 +271,7 @@ class TestSimpleCache(unittest.TestCase):
     Returns:
     A wrapped Node object with the given 'timestamp' and 'creationTimestamp'.
     """
-    assert isinstance(seconds, (types.IntType, types.LongType, types.FloatType))
+    assert isinstance(seconds, (int, long, float))
     return utilities.wrap_object(
         {'uid': KEY,
          'creationTimestamp': utilities.seconds_to_timestamp(seconds)},

--- a/collector/utilities.py
+++ b/collector/utilities.py
@@ -75,7 +75,7 @@ def seconds_to_timestamp(seconds):
   Returns:
   An ISO 8601 date/time value, which is YYYY-MM-DDTHH:MM:SS[.mmmmmm].
   """
-  assert isinstance(seconds, (types.IntType, types.LongType, types.FloatType))
+  assert isinstance(seconds, (int, long, float))
   return datetime.datetime.fromtimestamp(seconds).isoformat()
 
 
@@ -135,7 +135,7 @@ def global_state_dict_args(func):
   """
   def inner(arg1, arg2):
     assert isinstance(arg1, global_state.GlobalState)
-    assert isinstance(arg2, types.DictType) and arg2
+    assert isinstance(arg2, dict) and arg2
     return func(arg1, arg2)
 
   return inner
@@ -154,8 +154,8 @@ def two_dict_args(func):
   A decorated function.
   """
   def inner(arg1, arg2):
-    assert isinstance(arg1, types.DictType) and arg1
-    assert isinstance(arg2, types.DictType) and arg2
+    assert isinstance(arg1, dict) and arg1
+    assert isinstance(arg2, dict) and arg2
     return func(arg1, arg2)
 
   return inner
@@ -209,7 +209,7 @@ def is_wrapped_object(obj, expected_type=None):
           valid_string(get_attribute(obj, ['type'])) and
           ((expected_type is None) or (obj['type'] == expected_type)) and
           valid_string(get_attribute(obj, ['timestamp'])) and
-          isinstance(get_attribute(obj, ['properties']), types.DictType))
+          isinstance(get_attribute(obj, ['properties']), dict))
 
 
 def timeless_json_hash(obj):
@@ -332,11 +332,11 @@ def get_attribute(obj, names_list):
   The attribute value or None if any of the intermediate values is not a
   dictionary of any of the attributes in 'names_list' was not found.
   """
-  assert isinstance(names_list, types.ListType)
+  assert isinstance(names_list, list)
   v = obj
   for name in names_list:
     assert isinstance(name, types.StringTypes)
-    if isinstance(v, types.DictType) and (name in v):
+    if isinstance(v, dict) and (name in v):
       v = v[name]
     else:
       return None
@@ -357,7 +357,7 @@ def make_response(value, attribute_name):
   """
   assert valid_string(attribute_name)
   # Compute the maximum timestamp of the values in the list 'value'.
-  if (isinstance(value, types.ListType) and value and
+  if (isinstance(value, list) and value and
       all([is_wrapped_object(x) for x in value])):
     ts = value[0]['timestamp']  # we know that the list is not empty
     for x in value:

--- a/collector/utilities_test.py
+++ b/collector/utilities_test.py
@@ -19,7 +19,6 @@
 # global imports
 import json
 import time
-import types
 import unittest
 
 # local imports


### PR DESCRIPTION
The Python Standard Library documentation says this: "Starting in Python 2.2, built-in factory functions such as int() and str() are also names for the corresponding types. This is now the preferred way to access the type instead of using the types module."

I found the unidiomatic use of the types module distracting when reading this code.