### PR TITLE
Leverage Flask's testing flag instead of defining our own.

### DIFF
--- a/collector/collector_test.py
+++ b/collector/collector_test.py
@@ -43,9 +43,8 @@ class TestCollector(unittest.TestCase):
     os.environ['KUBERNETES_SERVICE_PORT'] = '443'
     gs = global_state.GlobalState()
     gs.init_caches_and_synchronization()
-    gs.set_testing(True)
     collector.app.context_graph_global_state = gs
-    collector.app.config['TESTING'] = True
+    collector.app.testing = True
     self.app = collector.app.test_client()
 
   def compare_to_golden(self, ret_value, fname):

--- a/collector/global_state.py
+++ b/collector/global_state.py
@@ -46,8 +46,6 @@ class GlobalState(object):
 
   def __init__(self):
     """Initialize internal state."""
-    self._testing = False
-
     # pointers to various caches.
     self._nodes_cache = None
     self._pods_cache = None
@@ -96,12 +94,6 @@ class GlobalState(object):
 
   def get_bounded_semaphore(self):
     return self._bounded_semaphore
-
-  def set_testing(self, testing):
-    self._testing = testing
-
-  def get_testing(self):
-    return self._testing
 
   def get_relations_to_timestamps(self):
     with self._relations_lock:

--- a/collector/kubernetes.py
+++ b/collector/kubernetes.py
@@ -140,7 +140,7 @@ def fetch_data(gs, url):
     fetch the URL.
   """
   start_time = time.time()
-  if gs.get_testing():
+  if app.testing:
     # Read the data from a file.
     url_elements = url.split('/')
     fname = 'testdata/' + url_elements[-1] + '.input.json'


### PR DESCRIPTION
The less stuff in global_state, the better.